### PR TITLE
Update spring.factories

### DIFF
--- a/sofa-boot-project/sofa-boot-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/sofa-boot-project/sofa-boot-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -1,11 +1,11 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-  com.alipay.sofa.boot.autoconfigure.runtime.SofaRuntimeAutoConfiguration, \
-  com.alipay.sofa.boot.autoconfigure.isle.SofaModuleAutoConfiguration, \
-  com.alipay.sofa.boot.autoconfigure.rpc.SofaRpcAutoConfiguration, \
-  com.alipay.sofa.boot.autoconfigure.tracer.OpenTracingSpringMvcAutoConfiguration, \
-  com.alipay.sofa.boot.autoconfigure.tracer.SofaTracerAutoConfiguration, \
-  com.alipay.sofa.boot.autoconfigure.tracer.SofaTracerDataSourceAutoConfiguration, \
-  com.alipay.sofa.boot.autoconfigure.tracer.SofaTracerFeignClientAutoConfiguration, \
+  com.alipay.sofa.boot.autoconfigure.runtime.SofaRuntimeAutoConfiguration,\
+  com.alipay.sofa.boot.autoconfigure.isle.SofaModuleAutoConfiguration,\
+  com.alipay.sofa.boot.autoconfigure.rpc.SofaRpcAutoConfiguration,\
+  com.alipay.sofa.boot.autoconfigure.tracer.OpenTracingSpringMvcAutoConfiguration,\
+  com.alipay.sofa.boot.autoconfigure.tracer.SofaTracerAutoConfiguration,\
+  com.alipay.sofa.boot.autoconfigure.tracer.SofaTracerDataSourceAutoConfiguration,\
+  com.alipay.sofa.boot.autoconfigure.tracer.SofaTracerFeignClientAutoConfiguration,\
   com.alipay.sofa.boot.autoconfigure.tracer.ZipkinSofaTracerAutoConfiguration,\
   com.alipay.sofa.boot.autoconfigure.tracer.SofaTracerRestTemplateAutoConfiguration,\
   com.alipay.sofa.boot.autoconfigure.tracer.TracerAnnotationAutoConfiguration


### PR DESCRIPTION
In version 3.2.0 of sofa-boot-autoconfigure-3.2.0.jar! /META-INF/spring.factories, some class paths are preceded by spaces, resulting in the following error: caused by: java.io.filenotfoundexception: class path resource [ com/alipay/sofa/boot/autoconfigure/isle/SofaModuleAutoConfiguration.class] cannot be opened because it does not exist。