### PR TITLE
Enable GRPC param configuration by resources

### DIFF
--- a/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/main/java/com/alipay/sofa/rpc/boot/config/SofaBootRpcConfigConstants.java
+++ b/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/main/java/com/alipay/sofa/rpc/boot/config/SofaBootRpcConfigConstants.java
@@ -43,6 +43,9 @@ public class SofaBootRpcConfigConstants {
     /* dubbo default configuration */
     public static final int     DUBBO_PORT_DEFAULT                 = 20880;
 
+    /* grpc default configuration */
+    public static final int     GRPC_PORT_DEFAULT                  = 50052;
+
     /* registry default configuration */
     public static final String  REGISTRY_FILE_PATH_DEFAULT         = System
                                                                        .getProperty("user.home")
@@ -73,6 +76,7 @@ public class SofaBootRpcConfigConstants {
     public static final String  RPC_PROTOCOL_DUBBO                 = "dubbo";
     public static final String  RPC_PROTOCOL_H2C                   = "h2c";
     public static final String  RPC_PROTOCOL_HTTP                  = "http";
+    public static final String  RPC_PROTOCOL_GRPC                  = "grpc";
 
     /** mesh **/
     public static final String  ENABLE_MESH_ALL                    = "all";

--- a/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/main/java/com/alipay/sofa/rpc/boot/config/SofaBootRpcProperties.java
+++ b/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/main/java/com/alipay/sofa/rpc/boot/config/SofaBootRpcProperties.java
@@ -213,6 +213,10 @@ public class SofaBootRpcProperties {
     private String              dubboAcceptsSize;
     /* dubbo  end*/
 
+    /* grpc start */
+    private String              grpcPort;
+    /* grpc end */
+
     /* http start*/
     /**
      * the port of http (http 端口)
@@ -534,6 +538,15 @@ public class SofaBootRpcProperties {
 
     public void setDubboAcceptsSize(String dubboAcceptsSize) {
         this.dubboAcceptsSize = dubboAcceptsSize;
+    }
+
+    public String getGrpcPort() {
+        return StringUtils.isEmpty(grpcPort) ? getDotString(new Object() {
+        }.getClass().getEnclosingMethod().getName()) : grpcPort;
+    }
+
+    public void setGrpcPort(String grpcPort) {
+        this.grpcPort = grpcPort;
     }
 
     public String getRegistryAddress() {

--- a/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/main/java/com/alipay/sofa/rpc/boot/container/ProviderConfigContainer.java
+++ b/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/main/java/com/alipay/sofa/rpc/boot/container/ProviderConfigContainer.java
@@ -154,6 +154,27 @@ public class ProviderConfigContainer {
     }
 
     /**
+     * export所有 Grpc 类型的 ProviderConfig
+     */
+    public void exportAllGrpcProvideConfig() {
+        for (ProviderConfig providerConfig : getAllProviderConfig()) {
+
+            ServerConfig serverConfig = (ServerConfig) providerConfig.getServer().get(0);
+            if (serverConfig.getProtocol().equalsIgnoreCase(
+                SofaBootRpcConfigConstants.RPC_PROTOCOL_GRPC)) {
+                providerConfig.setRegister(true);
+                providerConfig.export();
+
+                if (LOGGER.isInfoEnabled()) {
+                    LOGGER.info("service published.  interfaceId["
+                                + providerConfig.getInterfaceId() + "]; protocol["
+                                + serverConfig.getProtocol() + "]");
+                }
+            }
+        }
+    }
+
+    /**
      * unExport所有的 ProviderConfig
      */
     public void unExportAllProviderConfig() {

--- a/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/main/java/com/alipay/sofa/rpc/boot/runtime/adapter/GrpcBindingAdapter.java
+++ b/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/main/java/com/alipay/sofa/rpc/boot/runtime/adapter/GrpcBindingAdapter.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.rpc.boot.runtime.adapter;
+
+import com.alipay.sofa.rpc.boot.container.SpringBridge;
+import com.alipay.sofa.rpc.boot.runtime.binding.RpcBinding;
+import com.alipay.sofa.rpc.boot.runtime.binding.RpcBindingType;
+import com.alipay.sofa.rpc.log.LogCodes;
+import com.alipay.sofa.runtime.api.ServiceRuntimeException;
+import com.alipay.sofa.runtime.api.binding.BindingType;
+import com.alipay.sofa.runtime.spi.binding.Contract;
+import com.alipay.sofa.runtime.spi.component.SofaRuntimeContext;
+
+/**
+ * @author <a href=mailto:yqluan@gmail.com>Yanqiang Oliver Luan (neokidd)</a>
+ */
+public class GrpcBindingAdapter extends RpcBindingAdapter {
+
+    @Override
+    public BindingType getBindingType() {
+        return RpcBindingType.GRPC_BINDING_TYPE;
+    }
+
+    // @Override
+    // public Object outBinding(Object contract, RpcBinding binding, Object target, SofaRuntimeContext sofaRuntimeContext) {
+    //     return Boolean.TRUE;
+    // }
+
+    @Override
+    public void postUnoutBinding(Object contract, RpcBinding binding, Object target,
+                                 SofaRuntimeContext sofaRuntimeContext) {
+        try {
+            String key = SpringBridge.getProviderConfigContainer().createUniqueName(
+                (Contract) contract, binding);
+            SpringBridge.getProviderConfigContainer().removeProviderConfig(key);
+        } catch (Exception e) {
+            throw new ServiceRuntimeException(
+                LogCodes.getLog(LogCodes.ERROR_PROXY_POST_UNPUBLISH_FAIL), e);
+        }
+    }
+}

--- a/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/main/java/com/alipay/sofa/rpc/boot/runtime/binding/GrpcBinding.java
+++ b/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/main/java/com/alipay/sofa/rpc/boot/runtime/binding/GrpcBinding.java
@@ -16,24 +16,23 @@
  */
 package com.alipay.sofa.rpc.boot.runtime.binding;
 
+import com.alipay.sofa.rpc.boot.runtime.param.RpcBindingParam;
 import com.alipay.sofa.runtime.api.binding.BindingType;
+import org.springframework.context.ApplicationContext;
 
 /**
  *
- * @author <a href="mailto:lw111072@antfin.com">LiWei</a>
+ * @author <a href=mailto:yqluan@gmail.com>Yanqiang Oliver Luan (neokidd)</a>
  */
-public class RpcBindingType {
+public class GrpcBinding extends RpcBinding {
 
-    public static final BindingType BOLT_BINDING_TYPE  = new BindingType("bolt");
+    public GrpcBinding(RpcBindingParam bindingParam, ApplicationContext applicationContext,
+                       boolean inBinding) {
+        super(bindingParam, applicationContext, inBinding);
+    }
 
-    public static final BindingType REST_BINDING_TYPE  = new BindingType("rest");
-
-    public static final BindingType DUBBO_BINDING_TYPE = new BindingType("dubbo");
-
-    public static final BindingType H2C_BINDING_TYPE   = new BindingType("h2c");
-
-    public static final BindingType HTTP_BINDING_TYPE  = new BindingType("http");
-
-    public static final BindingType GRPC_BINDING_TYPE  = new BindingType("grpc");
-
+    @Override
+    public BindingType getBindingType() {
+        return RpcBindingType.GRPC_BINDING_TYPE;
+    }
 }

--- a/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/main/java/com/alipay/sofa/rpc/boot/runtime/converter/GrpcBindingConverter.java
+++ b/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/main/java/com/alipay/sofa/rpc/boot/runtime/converter/GrpcBindingConverter.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.rpc.boot.runtime.converter;
+
+import com.alipay.sofa.rpc.boot.config.SofaBootRpcConfigConstants;
+import com.alipay.sofa.rpc.boot.runtime.binding.BoltBinding;
+import com.alipay.sofa.rpc.boot.runtime.binding.GrpcBinding;
+import com.alipay.sofa.rpc.boot.runtime.binding.RpcBinding;
+import com.alipay.sofa.rpc.boot.runtime.binding.RpcBindingType;
+import com.alipay.sofa.rpc.boot.runtime.param.BoltBindingParam;
+import com.alipay.sofa.rpc.boot.runtime.param.GrpcBindingParam;
+import com.alipay.sofa.rpc.boot.runtime.param.RpcBindingParam;
+import com.alipay.sofa.runtime.api.annotation.SofaReference;
+import com.alipay.sofa.runtime.api.annotation.SofaReferenceBinding;
+import com.alipay.sofa.runtime.api.annotation.SofaService;
+import com.alipay.sofa.runtime.api.annotation.SofaServiceBinding;
+import com.alipay.sofa.runtime.api.binding.BindingType;
+import com.alipay.sofa.runtime.spi.service.BindingConverterContext;
+import org.springframework.context.ApplicationContext;
+
+/**
+ * @author <a href=mailto:yqluan@gmail.com>Yanqiang Oliver Luan (neokidd)</a>
+ */
+public class GrpcBindingConverter extends RpcBindingConverter {
+
+    @Override
+    protected RpcBinding createRpcBinding(RpcBindingParam bindingParam,
+                                          ApplicationContext applicationContext, boolean inBinding) {
+        return new GrpcBinding(bindingParam, applicationContext, inBinding);
+    }
+
+    @Override
+    protected RpcBindingParam createRpcBindingParam() {
+        return new GrpcBindingParam();
+    }
+
+    @Override
+    public RpcBinding convert(SofaService sofaServiceAnnotation,
+                              SofaServiceBinding sofaServiceBindingAnnotation,
+                              BindingConverterContext bindingConverterContext) {
+        RpcBindingParam bindingParam = new GrpcBindingParam();
+        convertServiceAnnotation(bindingParam, sofaServiceAnnotation, sofaServiceBindingAnnotation,
+            bindingConverterContext);
+        return new GrpcBinding(bindingParam, bindingConverterContext.getApplicationContext(),
+            bindingConverterContext.isInBinding());
+    }
+
+    @Override
+    public RpcBinding convert(SofaReference sofaReferenceAnnotation,
+                              SofaReferenceBinding sofaReferenceBindingAnnotation,
+                              BindingConverterContext bindingConverterContext) {
+        RpcBindingParam bindingParam = new GrpcBindingParam();
+        convertReferenceAnnotation(bindingParam, sofaReferenceBindingAnnotation,
+            bindingConverterContext);
+
+        return new GrpcBinding(bindingParam, bindingConverterContext.getApplicationContext(),
+            bindingConverterContext.isInBinding());
+    }
+
+    @Override
+    public BindingType supportBindingType() {
+        return RpcBindingType.GRPC_BINDING_TYPE;
+    }
+
+    @Override
+    public String supportTagName() {
+        return "binding." + SofaBootRpcConfigConstants.RPC_PROTOCOL_GRPC;
+    }
+}

--- a/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/main/java/com/alipay/sofa/rpc/boot/runtime/param/GrpcBindingParam.java
+++ b/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/main/java/com/alipay/sofa/rpc/boot/runtime/param/GrpcBindingParam.java
@@ -14,26 +14,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.alipay.sofa.rpc.boot.runtime.binding;
+package com.alipay.sofa.rpc.boot.runtime.param;
 
+import com.alipay.sofa.rpc.boot.runtime.binding.RpcBindingType;
 import com.alipay.sofa.runtime.api.binding.BindingType;
 
 /**
  *
- * @author <a href="mailto:lw111072@antfin.com">LiWei</a>
+ * @author <a href=mailto:yqluan@gmail.com>Yanqiang Oliver Luan (neokidd)</a>
  */
-public class RpcBindingType {
+public class GrpcBindingParam extends RpcBindingParam {
 
-    public static final BindingType BOLT_BINDING_TYPE  = new BindingType("bolt");
-
-    public static final BindingType REST_BINDING_TYPE  = new BindingType("rest");
-
-    public static final BindingType DUBBO_BINDING_TYPE = new BindingType("dubbo");
-
-    public static final BindingType H2C_BINDING_TYPE   = new BindingType("h2c");
-
-    public static final BindingType HTTP_BINDING_TYPE  = new BindingType("http");
-
-    public static final BindingType GRPC_BINDING_TYPE  = new BindingType("grpc");
-
+    @Override
+    public BindingType getBindingType() {
+        return RpcBindingType.GRPC_BINDING_TYPE;
+    }
 }


### PR DESCRIPTION
Motivation:
As GRPC protocol was supported with #716 in sofa-rpc project, it shall allow configuring RPC params by resource files like using another protocols.

Modification:
Added configure constants, params, binding, adapter and converter. All for support of and prefix with Grpc. Minimal touch to core.

Result:
It enables support of configuring GRPC params by resource files.
It's merged with the latest master. No conflicts. Ready for PR.