### PR TITLE
chore:update dubbo version

### DIFF
--- a/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/pom.xml
+++ b/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/pom.xml
@@ -16,7 +16,7 @@
         <main.user.dir>${basedir}/../../..</main.user.dir>
         <swagger.version>2.0.0</swagger.version>
         <curator.version>4.0.1</curator.version>
-        <dubbo_version>2.4.10</dubbo_version>
+        <dubbo_version>2.6.7</dubbo_version>
         <zkclient.version>0.11</zkclient.version>
     </properties>
 

--- a/sofa-boot-project/sofaboot-dependencies/pom.xml
+++ b/sofa-boot-project/sofaboot-dependencies/pom.xml
@@ -50,7 +50,7 @@
 
         <resteasy.version>3.6.3.Final</resteasy.version>
         <curator.version>4.0.1</curator.version>
-        <dubbo_version>2.4.10</dubbo_version>
+        <dubbo_version>2.6.7</dubbo_version>
         <zkclient.version>0.11</zkclient.version>
         <nacos.version>1.0.0</nacos.version>
 


### PR DESCRIPTION
update dubbo 2.6.7

dubbo 低版本时间比较久，存在一些兼容问题，目前rpc已经在5.6.4中升级，因为sofaboot同时升级