### PR TITLE
Sort BindingAdapter and BindingConverter so that users can easily override them

### DIFF
--- a/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/test/java/com/alipay/sofa/rpc/boot/test/adapter/BindingAdapterFactoryTest.java
+++ b/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/test/java/com/alipay/sofa/rpc/boot/test/adapter/BindingAdapterFactoryTest.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.rpc.boot.test.adapter;
+
+import com.alipay.sofa.rpc.boot.test.RuntimeTestConfiguration;
+import com.alipay.sofa.runtime.service.impl.BindingAdapterFactoryImpl;
+import com.alipay.sofa.runtime.spi.binding.BindingAdapter;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author zhaowang
+ * @version : BindingAdatperFactoryTest.java, v 0.1 2020年02月05日 2:46 下午 zhaowang Exp $
+ */
+public class BindingAdapterFactoryTest {
+
+    @Test
+    public void testOrder() {
+        BindingAdapterFactoryImpl bindingAdapterFactory = new BindingAdapterFactoryImpl();
+        bindingAdapterFactory.addBindingAdapters(RuntimeTestConfiguration
+            .getClassesByServiceLoader(BindingAdapter.class));
+        BindingAdapter bindingAdapter = bindingAdapterFactory.getBindingAdapter(XBindingAdapter.X);
+        Assert.assertTrue(bindingAdapter instanceof XBindingAdapter2);
+    }
+}

--- a/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/test/java/com/alipay/sofa/rpc/boot/test/adapter/XBindingAdapter.java
+++ b/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/test/java/com/alipay/sofa/rpc/boot/test/adapter/XBindingAdapter.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.rpc.boot.test.adapter;
+
+import com.alipay.sofa.rpc.boot.runtime.adapter.RpcBindingAdapter;
+import com.alipay.sofa.runtime.api.binding.BindingType;
+import org.springframework.core.annotation.Order;
+
+/**
+ * @author zhaowang
+ * @version : XBandingAdaptor.java, v 0.1 2020年02月05日 2:36 下午 zhaowang Exp $
+ */
+@Order(value = 2)
+public class XBindingAdapter extends RpcBindingAdapter {
+    public static final BindingType X = new BindingType("X");
+
+    @Override
+    public BindingType getBindingType() {
+        return X;
+    }
+}

--- a/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/test/java/com/alipay/sofa/rpc/boot/test/adapter/XBindingAdapter2.java
+++ b/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/test/java/com/alipay/sofa/rpc/boot/test/adapter/XBindingAdapter2.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.rpc.boot.test.adapter;
+
+import com.alipay.sofa.rpc.boot.runtime.adapter.RpcBindingAdapter;
+import com.alipay.sofa.runtime.api.binding.BindingType;
+import org.springframework.core.annotation.Order;
+
+/**
+ * @author zhaowang
+ * @version : XBandingAdaptor.java, v 0.1 2020年02月05日 2:36 下午 zhaowang Exp $
+ */
+@Order(value = 1)
+public class XBindingAdapter2 extends RpcBindingAdapter {
+
+    @Override
+    public BindingType getBindingType() {
+        return XBindingAdapter.X;
+    }
+}

--- a/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/test/java/com/alipay/sofa/rpc/boot/test/adapter/XBindingAdapter3.java
+++ b/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/test/java/com/alipay/sofa/rpc/boot/test/adapter/XBindingAdapter3.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.rpc.boot.test.adapter;
+
+import com.alipay.sofa.rpc.boot.runtime.adapter.RpcBindingAdapter;
+import com.alipay.sofa.runtime.api.binding.BindingType;
+import org.springframework.core.annotation.Order;
+
+/**
+ * @author zhaowang
+ * @version : XBandingAdaptor.java, v 0.1 2020年02月05日 2:36 下午 zhaowang Exp $
+ */
+@Order(value = 3)
+public class XBindingAdapter3 extends RpcBindingAdapter {
+
+    @Override
+    public BindingType getBindingType() {
+        return XBindingAdapter.X;
+    }
+}

--- a/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/test/java/com/alipay/sofa/rpc/boot/test/converter/RpcBindingConverterTest.java
+++ b/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/test/java/com/alipay/sofa/rpc/boot/test/converter/RpcBindingConverterTest.java
@@ -18,6 +18,12 @@ package com.alipay.sofa.rpc.boot.test.converter;
 
 import java.util.List;
 
+import com.alipay.sofa.rpc.boot.test.RuntimeTestConfiguration;
+import com.alipay.sofa.runtime.service.impl.BindingConverterFactoryImpl;
+import com.alipay.sofa.runtime.spi.binding.BindingAdapter;
+import com.alipay.sofa.runtime.spi.binding.BindingAdapterFactory;
+import com.alipay.sofa.runtime.spi.service.BindingConverter;
+import com.alipay.sofa.runtime.spi.service.BindingConverterFactory;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -63,4 +69,18 @@ public class RpcBindingConverterTest {
         Assert.assertEquals(2000, rpcBindingMethodInfo.getTimeout().intValue());
 
     }
+
+    @Test
+    public void testOrder() {
+        BindingConverterFactory factory = new BindingConverterFactoryImpl();
+        factory.addBindingConverters(RuntimeTestConfiguration
+            .getClassesByServiceLoader(BindingConverter.class));
+        BindingConverter bindingConverter = factory.getBindingConverter(TestBindingConverter.TEST);
+        BindingConverter bindingConverterByTagName = factory
+            .getBindingConverterByTagName(TestBindingConverter.TARGET_NAME);
+
+        Assert.assertTrue(bindingConverter instanceof TestBindingConverter2);
+        Assert.assertTrue(bindingConverterByTagName instanceof TestBindingConverter2);
+    }
+
 }

--- a/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/test/java/com/alipay/sofa/rpc/boot/test/converter/TestBindingConverter.java
+++ b/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/test/java/com/alipay/sofa/rpc/boot/test/converter/TestBindingConverter.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.rpc.boot.test.converter;
+
+import com.alipay.sofa.rpc.boot.runtime.binding.RpcBinding;
+import com.alipay.sofa.rpc.boot.runtime.converter.RpcBindingConverter;
+import com.alipay.sofa.rpc.boot.runtime.param.RpcBindingParam;
+import com.alipay.sofa.runtime.api.annotation.SofaReference;
+import com.alipay.sofa.runtime.api.annotation.SofaReferenceBinding;
+import com.alipay.sofa.runtime.api.annotation.SofaService;
+import com.alipay.sofa.runtime.api.annotation.SofaServiceBinding;
+import com.alipay.sofa.runtime.api.binding.BindingType;
+import com.alipay.sofa.runtime.spi.service.BindingConverterContext;
+import org.springframework.context.ApplicationContext;
+
+/**
+ * @author zhaowang
+ * @version : TestBindingConverter.java, v 0.1 2020年02月05日 2:58 下午 zhaowang Exp $
+ */
+public class TestBindingConverter extends RpcBindingConverter {
+    public static final BindingType TEST        = new BindingType("TEST");
+    public static final String      TARGET_NAME = "test";
+
+    @Override
+    protected RpcBinding createRpcBinding(RpcBindingParam bindingParam,
+                                          ApplicationContext applicationContext, boolean inBinding) {
+        return null;
+    }
+
+    @Override
+    protected RpcBindingParam createRpcBindingParam() {
+        return null;
+    }
+
+    @Override
+    public RpcBinding convert(SofaService sofaServiceAnnotation,
+                              SofaServiceBinding sofaServiceBindingAnnotation,
+                              BindingConverterContext bindingConverterContext) {
+        return null;
+    }
+
+    @Override
+    public RpcBinding convert(SofaReference sofaReferenceAnnotation,
+                              SofaReferenceBinding sofaReferenceBindingAnnotation,
+                              BindingConverterContext bindingConverterContext) {
+        return null;
+    }
+
+    @Override
+    public BindingType supportBindingType() {
+        return TEST;
+    }
+
+    @Override
+    public String supportTagName() {
+        return TARGET_NAME;
+    }
+}

--- a/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/test/java/com/alipay/sofa/rpc/boot/test/converter/TestBindingConverter2.java
+++ b/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/test/java/com/alipay/sofa/rpc/boot/test/converter/TestBindingConverter2.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.rpc.boot.test.converter;
+
+import com.alipay.sofa.rpc.boot.runtime.binding.RpcBinding;
+import com.alipay.sofa.rpc.boot.runtime.converter.RpcBindingConverter;
+import com.alipay.sofa.rpc.boot.runtime.param.RpcBindingParam;
+import com.alipay.sofa.runtime.api.annotation.SofaReference;
+import com.alipay.sofa.runtime.api.annotation.SofaReferenceBinding;
+import com.alipay.sofa.runtime.api.annotation.SofaService;
+import com.alipay.sofa.runtime.api.annotation.SofaServiceBinding;
+import com.alipay.sofa.runtime.api.binding.BindingType;
+import com.alipay.sofa.runtime.spi.service.BindingConverterContext;
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.annotation.Order;
+
+import static com.alipay.sofa.rpc.boot.test.converter.TestBindingConverter.TARGET_NAME;
+import static com.alipay.sofa.rpc.boot.test.converter.TestBindingConverter.TEST;
+
+/**
+ * @author zhaowang
+ * @version : TestBindingConverter.java, v 0.1 2020年02月05日 2:58 下午 zhaowang Exp $
+ */
+@Order(1)
+public class TestBindingConverter2 extends RpcBindingConverter {
+    @Override
+    protected RpcBinding createRpcBinding(RpcBindingParam bindingParam,
+                                          ApplicationContext applicationContext, boolean inBinding) {
+        return null;
+    }
+
+    @Override
+    protected RpcBindingParam createRpcBindingParam() {
+        return null;
+    }
+
+    @Override
+    public RpcBinding convert(SofaService sofaServiceAnnotation,
+                              SofaServiceBinding sofaServiceBindingAnnotation,
+                              BindingConverterContext bindingConverterContext) {
+        return null;
+    }
+
+    @Override
+    public RpcBinding convert(SofaReference sofaReferenceAnnotation,
+                              SofaReferenceBinding sofaReferenceBindingAnnotation,
+                              BindingConverterContext bindingConverterContext) {
+        return null;
+    }
+
+    @Override
+    public BindingType supportBindingType() {
+        return TEST;
+    }
+
+    @Override
+    public String supportTagName() {
+        return TARGET_NAME;
+    }
+}

--- a/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/test/java/com/alipay/sofa/rpc/boot/test/converter/TestBindingConverter3.java
+++ b/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/test/java/com/alipay/sofa/rpc/boot/test/converter/TestBindingConverter3.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.rpc.boot.test.converter;
+
+import com.alipay.sofa.rpc.boot.runtime.binding.RpcBinding;
+import com.alipay.sofa.rpc.boot.runtime.converter.RpcBindingConverter;
+import com.alipay.sofa.rpc.boot.runtime.param.RpcBindingParam;
+import com.alipay.sofa.runtime.api.annotation.SofaReference;
+import com.alipay.sofa.runtime.api.annotation.SofaReferenceBinding;
+import com.alipay.sofa.runtime.api.annotation.SofaService;
+import com.alipay.sofa.runtime.api.annotation.SofaServiceBinding;
+import com.alipay.sofa.runtime.api.binding.BindingType;
+import com.alipay.sofa.runtime.spi.service.BindingConverterContext;
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.annotation.Order;
+
+import static com.alipay.sofa.rpc.boot.test.converter.TestBindingConverter.TARGET_NAME;
+import static com.alipay.sofa.rpc.boot.test.converter.TestBindingConverter.TEST;
+
+/**
+ * @author zhaowang
+ * @version : TestBindingConverter.java, v 0.1 2020年02月05日 2:58 下午 zhaowang Exp $
+ */
+@Order(2)
+public class TestBindingConverter3 extends RpcBindingConverter {
+    @Override
+    protected RpcBinding createRpcBinding(RpcBindingParam bindingParam,
+                                          ApplicationContext applicationContext, boolean inBinding) {
+        return null;
+    }
+
+    @Override
+    protected RpcBindingParam createRpcBindingParam() {
+        return null;
+    }
+
+    @Override
+    public RpcBinding convert(SofaService sofaServiceAnnotation,
+                              SofaServiceBinding sofaServiceBindingAnnotation,
+                              BindingConverterContext bindingConverterContext) {
+        return null;
+    }
+
+    @Override
+    public RpcBinding convert(SofaReference sofaReferenceAnnotation,
+                              SofaReferenceBinding sofaReferenceBindingAnnotation,
+                              BindingConverterContext bindingConverterContext) {
+        return null;
+    }
+
+    @Override
+    public BindingType supportBindingType() {
+        return TEST;
+    }
+
+    @Override
+    public String supportTagName() {
+        return TARGET_NAME;
+    }
+}

--- a/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/test/resources/META-INF/services/com.alipay.sofa.runtime.spi.binding.BindingAdapter
+++ b/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/test/resources/META-INF/services/com.alipay.sofa.runtime.spi.binding.BindingAdapter
@@ -3,3 +3,6 @@ com.alipay.sofa.rpc.boot.runtime.adapter.RestBindingAdapter
 com.alipay.sofa.rpc.boot.runtime.adapter.DubboBindingAdapter
 com.alipay.sofa.rpc.boot.runtime.adapter.H2cBindingAdapter
 com.alipay.sofa.rpc.boot.runtime.adapter.HttpBindingAdapter
+com.alipay.sofa.rpc.boot.test.adapter.XBindingAdapter
+com.alipay.sofa.rpc.boot.test.adapter.XBindingAdapter2
+com.alipay.sofa.rpc.boot.test.adapter.XBindingAdapter3

--- a/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/test/resources/META-INF/services/com.alipay.sofa.runtime.spi.service.BindingConverter
+++ b/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/test/resources/META-INF/services/com.alipay.sofa.runtime.spi.service.BindingConverter
@@ -3,3 +3,7 @@ com.alipay.sofa.rpc.boot.runtime.converter.RestBindingConverter
 com.alipay.sofa.rpc.boot.runtime.converter.DubboBindingConverter
 com.alipay.sofa.rpc.boot.runtime.converter.H2cBindingConverter
 com.alipay.sofa.rpc.boot.runtime.converter.HttpBindingConverter
+
+com.alipay.sofa.rpc.boot.test.converter.TestBindingConverter
+com.alipay.sofa.rpc.boot.test.converter.TestBindingConverter2
+com.alipay.sofa.rpc.boot.test.converter.TestBindingConverter3

--- a/sofa-boot-project/sofa-boot-core/runtime-sofa-boot/src/main/java/com/alipay/sofa/runtime/service/impl/BindingAdapterFactoryImpl.java
+++ b/sofa-boot-project/sofa-boot-core/runtime-sofa-boot/src/main/java/com/alipay/sofa/runtime/service/impl/BindingAdapterFactoryImpl.java
@@ -16,13 +16,16 @@
  */
 package com.alipay.sofa.runtime.service.impl;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
-
 import com.alipay.sofa.runtime.api.binding.BindingType;
 import com.alipay.sofa.runtime.spi.binding.BindingAdapter;
 import com.alipay.sofa.runtime.spi.binding.BindingAdapterFactory;
+import org.springframework.core.annotation.AnnotationAwareOrderComparator;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * @author xuanbei 18/2/28
@@ -40,8 +43,12 @@ public class BindingAdapterFactoryImpl implements BindingAdapterFactory {
         if (bindingAdapters == null || bindingAdapters.size() == 0) {
             return;
         }
-        for (BindingAdapter bindingAdapter : bindingAdapters) {
-            bindingTypeBindingAdapterMap.put(bindingAdapter.getBindingType(), bindingAdapter);
+        List<BindingAdapter> sortedBindingAdapters = new ArrayList<>(bindingAdapters);
+        sortedBindingAdapters.sort(AnnotationAwareOrderComparator.INSTANCE);
+
+        for (BindingAdapter bindingAdapter : sortedBindingAdapters) {
+            bindingTypeBindingAdapterMap.putIfAbsent(bindingAdapter.getBindingType(),
+                bindingAdapter);
         }
     }
 }

--- a/sofa-boot-project/sofa-boot-core/runtime-sofa-boot/src/main/java/com/alipay/sofa/runtime/service/impl/BindingConverterFactoryImpl.java
+++ b/sofa-boot-project/sofa-boot-core/runtime-sofa-boot/src/main/java/com/alipay/sofa/runtime/service/impl/BindingConverterFactoryImpl.java
@@ -16,13 +16,17 @@
  */
 package com.alipay.sofa.runtime.service.impl;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
-
 import com.alipay.sofa.runtime.api.binding.BindingType;
 import com.alipay.sofa.runtime.spi.service.BindingConverter;
 import com.alipay.sofa.runtime.spi.service.BindingConverterFactory;
+import org.springframework.core.OrderComparator;
+import org.springframework.core.annotation.AnnotationAwareOrderComparator;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * @author xuanbei 18/2/28
@@ -46,10 +50,14 @@ public class BindingConverterFactoryImpl implements BindingConverterFactory {
         if (bindingConverters == null || bindingConverters.size() == 0) {
             return;
         }
-        for (BindingConverter bindingConverter : bindingConverters) {
-            bindingTypeBindingConverterMap.put(bindingConverter.supportBindingType(),
+
+        List<BindingConverter> sortedBindingConverter = new ArrayList<>(bindingConverters);
+        sortedBindingConverter.sort(AnnotationAwareOrderComparator.INSTANCE);
+
+        for (BindingConverter bindingConverter : sortedBindingConverter) {
+            bindingTypeBindingConverterMap.putIfAbsent(bindingConverter.supportBindingType(),
                 bindingConverter);
-            tagBindingConverterMap.put(bindingConverter.supportTagName(), bindingConverter);
+            tagBindingConverterMap.putIfAbsent(bindingConverter.supportTagName(), bindingConverter);
         }
     }
 }

--- a/sofa-boot-project/sofa-boot-tools/sofa-boot-gradle-plugin/pom.xml
+++ b/sofa-boot-project/sofa-boot-tools/sofa-boot-gradle-plugin/pom.xml
@@ -168,6 +168,7 @@
             </activation>
             <properties>
                 <gradle.task>assemble</gradle.task>
+                <skip.gradle.build>true</skip.gradle.build>
             </properties>
         </profile>
     </profiles>


### PR DESCRIPTION
use @Order annotation to sort BindingAdapter or BindingConverter in factory, so that users can easily override them. 

When get object from factory(BindingAdapterFactory or  BindingConverterFactory ),users will get the object who has highest precedence

fix #543