### PR TITLE
support mock setting

### DIFF
--- a/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/rpc/SofaRpcAutoConfiguration.java
+++ b/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/rpc/SofaRpcAutoConfiguration.java
@@ -37,6 +37,11 @@ import com.alipay.sofa.rpc.boot.context.SofaBootRpcStartListener;
 import com.alipay.sofa.rpc.boot.health.RpcAfterHealthCheckCallback;
 import com.alipay.sofa.rpc.boot.runtime.adapter.helper.ConsumerConfigHelper;
 import com.alipay.sofa.rpc.boot.runtime.adapter.helper.ProviderConfigHelper;
+import com.alipay.sofa.rpc.boot.runtime.adapter.processor.ConsumerConfigProcessor;
+import com.alipay.sofa.rpc.boot.runtime.adapter.processor.ConsumerMockProcessor;
+import com.alipay.sofa.rpc.boot.runtime.adapter.processor.DynamicConfigProcessor;
+import com.alipay.sofa.rpc.boot.runtime.adapter.processor.ProcessorContainer;
+import com.alipay.sofa.rpc.boot.runtime.adapter.processor.ProviderConfigProcessor;
 import com.alipay.sofa.rpc.boot.swagger.SwaggerServiceApplicationListener;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.actuate.health.Health;
@@ -186,4 +191,23 @@ public class SofaRpcAutoConfiguration {
             return new RpcAfterHealthCheckCallback();
         }
     }
+
+    @Bean
+    public ProcessorContainer processorContainer(List<ProviderConfigProcessor> providerConfigProcessors,
+                                                 List<ConsumerConfigProcessor> consumerConfigProcessors) {
+        return new ProcessorContainer(providerConfigProcessors, consumerConfigProcessors);
+    }
+
+    @Bean
+    @ConditionalOnProperty(name = "com.alipay.sofa.rpc.mock-url")
+    public ConsumerMockProcessor consumerMockProcessor() {
+        return new ConsumerMockProcessor();
+    }
+
+    @Bean
+    @ConditionalOnProperty(name = "com.alipay.sofa.rpc.dynamic-config")
+    public DynamicConfigProcessor dynamicConfigProcessor() {
+        return new DynamicConfigProcessor();
+    }
+
 }

--- a/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/main/java/com/alipay/sofa/rpc/boot/config/SofaBootRpcProperties.java
+++ b/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/main/java/com/alipay/sofa/rpc/boot/config/SofaBootRpcProperties.java
@@ -103,6 +103,11 @@ public class SofaBootRpcProperties {
      * the max accept size of bolt (bolt 服务端允许客户端建立的连接数)
      */
     private String              boltAcceptsSize;
+
+    /**
+     * Location of remote mock server . If specified ,auto enable mock.
+     */
+    private String              mockUrl;
     /* Bolt end*/
 
     /* H2c start*/
@@ -294,6 +299,11 @@ public class SofaBootRpcProperties {
     private String              hystrixEnable;
 
     private String              defaultTracer;
+
+    /**
+     * dynamic config setting
+     */
+    private String              dynamicConfig;
 
     public String getAftRegulationEffective() {
         return StringUtils.isEmpty(aftRegulationEffective) ? getDotString(new Object() {
@@ -818,4 +828,21 @@ public class SofaBootRpcProperties {
     public void setRestSwagger(boolean restSwagger) {
         this.restSwagger = restSwagger;
     }
+
+    public String getMockUrl() {
+        return mockUrl;
+    }
+
+    public void setMockUrl(String mockUrl) {
+        this.mockUrl = mockUrl;
+    }
+
+    public String getDynamicConfig() {
+        return dynamicConfig;
+    }
+
+    public void setDynamicConfig(String dynamicConfig) {
+        this.dynamicConfig = dynamicConfig;
+    }
+
 }

--- a/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/main/java/com/alipay/sofa/rpc/boot/container/ConsumerConfigContainer.java
+++ b/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/main/java/com/alipay/sofa/rpc/boot/container/ConsumerConfigContainer.java
@@ -59,4 +59,8 @@ public class ConsumerConfigContainer {
             }
         }
     }
+
+    public ConcurrentMap<Binding, ConsumerConfig> getConsumerConfigMap() {
+        return consumerConfigMap;
+    }
 }

--- a/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/main/java/com/alipay/sofa/rpc/boot/runtime/adapter/RpcBindingAdapter.java
+++ b/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/main/java/com/alipay/sofa/rpc/boot/runtime/adapter/RpcBindingAdapter.java
@@ -22,6 +22,7 @@ import com.alipay.sofa.rpc.boot.runtime.adapter.helper.ConsumerConfigHelper;
 import com.alipay.sofa.rpc.boot.runtime.adapter.helper.ProviderConfigHelper;
 import com.alipay.sofa.rpc.boot.runtime.binding.RpcBinding;
 import com.alipay.sofa.rpc.boot.runtime.param.RpcBindingParam;
+import com.alipay.sofa.rpc.common.MockMode;
 import com.alipay.sofa.rpc.config.ConsumerConfig;
 import com.alipay.sofa.rpc.config.ProviderConfig;
 import com.alipay.sofa.rpc.config.RegistryConfig;
@@ -199,6 +200,11 @@ public abstract class RpcBindingAdapter implements BindingAdapter<RpcBinding> {
 
         ConsumerConfig consumerConfig = consumerConfigHelper.getConsumerConfig((Contract) contract,
             binding);
+
+        if (MockMode.LOCAL.equalsIgnoreCase(binding.getRpcBindingParam().getMockMode())) {
+            consumerConfig.setMockRef(consumerConfigHelper.getMockRef(binding, applicationContext));
+        }
+
         consumerConfigContainer.addConsumerConfig(binding, consumerConfig);
 
         try {

--- a/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/main/java/com/alipay/sofa/rpc/boot/runtime/adapter/RpcBindingAdapter.java
+++ b/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/main/java/com/alipay/sofa/rpc/boot/runtime/adapter/RpcBindingAdapter.java
@@ -20,6 +20,7 @@ import com.alipay.sofa.rpc.boot.container.ConsumerConfigContainer;
 import com.alipay.sofa.rpc.boot.container.ProviderConfigContainer;
 import com.alipay.sofa.rpc.boot.runtime.adapter.helper.ConsumerConfigHelper;
 import com.alipay.sofa.rpc.boot.runtime.adapter.helper.ProviderConfigHelper;
+import com.alipay.sofa.rpc.boot.runtime.adapter.processor.ProcessorContainer;
 import com.alipay.sofa.rpc.boot.runtime.binding.RpcBinding;
 import com.alipay.sofa.rpc.boot.runtime.param.RpcBindingParam;
 import com.alipay.sofa.rpc.common.MockMode;
@@ -91,9 +92,12 @@ public abstract class RpcBindingAdapter implements BindingAdapter<RpcBinding> {
             .getRootApplicationContext();
         ProviderConfigContainer providerConfigContainer = applicationContext
             .getBean(ProviderConfigContainer.class);
+        ProcessorContainer processorContainer = applicationContext
+            .getBean(ProcessorContainer.class);
 
         String uniqueName = providerConfigContainer.createUniqueName((Contract) contract, binding);
         ProviderConfig providerConfig = providerConfigContainer.getProviderConfig(uniqueName);
+        processorContainer.processorProvider(providerConfig);
 
         if (providerConfig == null) {
             throw new ServiceRuntimeException(LogCodes.getLog(
@@ -197,9 +201,12 @@ public abstract class RpcBindingAdapter implements BindingAdapter<RpcBinding> {
             .getBean(ConsumerConfigHelper.class);
         ConsumerConfigContainer consumerConfigContainer = applicationContext
             .getBean(ConsumerConfigContainer.class);
+        ProcessorContainer processorContainer = applicationContext
+            .getBean(ProcessorContainer.class);
 
         ConsumerConfig consumerConfig = consumerConfigHelper.getConsumerConfig((Contract) contract,
             binding);
+        processorContainer.processorConsumer(consumerConfig);
 
         if (MockMode.LOCAL.equalsIgnoreCase(binding.getRpcBindingParam().getMockMode())) {
             consumerConfig.setMockRef(consumerConfigHelper.getMockRef(binding, applicationContext));

--- a/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/main/java/com/alipay/sofa/rpc/boot/runtime/adapter/helper/ConsumerConfigHelper.java
+++ b/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/main/java/com/alipay/sofa/rpc/boot/runtime/adapter/helper/ConsumerConfigHelper.java
@@ -19,6 +19,7 @@ package com.alipay.sofa.rpc.boot.runtime.adapter.helper;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.springframework.context.ApplicationContext;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 
@@ -78,6 +79,7 @@ public class ConsumerConfigHelper {
         String loadBalancer = param.getLoadBalancer();
         Boolean lazy = param.getLazy();
         Boolean check = param.getCheck();
+        String mockMode = param.getMockMode();
 
         String serialization = param.getSerialization();
         List<Filter> filters = param.getFilters();
@@ -122,6 +124,9 @@ public class ConsumerConfigHelper {
         }
         if (check != null) {
             consumerConfig.setCheck(check);
+        }
+        if (mockMode != null) {
+            consumerConfig.setMockMode(mockMode);
         }
         if (callbackHandler != null) {
             if (callbackHandler instanceof SofaResponseCallback) {
@@ -230,5 +235,16 @@ public class ConsumerConfigHelper {
         }
 
         return methodConfigs;
+    }
+
+    public Object getMockRef(RpcBinding binding, ApplicationContext applicationContext) {
+        RpcBindingParam rpcBindingParam = binding.getRpcBindingParam();
+        String mockBean = rpcBindingParam.getMockBean();
+
+        if (StringUtils.hasText(mockBean)) {
+            return applicationContext.getBean(mockBean);
+        } else {
+            throw new IllegalArgumentException("Mock mode is open, mock bean can't be empty.");
+        }
     }
 }

--- a/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/main/java/com/alipay/sofa/rpc/boot/runtime/adapter/processor/ConsumerConfigProcessor.java
+++ b/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/main/java/com/alipay/sofa/rpc/boot/runtime/adapter/processor/ConsumerConfigProcessor.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.rpc.boot.runtime.adapter.processor;
+
+import com.alipay.sofa.rpc.config.ConsumerConfig;
+
+/**
+ * @author zhaowang
+ * @version : ConsumerConfigProcessor.java, v 0.1 2020年03月11日 10:34 上午 zhaowang Exp $
+ */
+public interface ConsumerConfigProcessor {
+
+    void processorConsumer(ConsumerConfig consumerConfig);
+}

--- a/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/main/java/com/alipay/sofa/rpc/boot/runtime/adapter/processor/ConsumerMockProcessor.java
+++ b/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/main/java/com/alipay/sofa/rpc/boot/runtime/adapter/processor/ConsumerMockProcessor.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.rpc.boot.runtime.adapter.processor;
+
+import com.alipay.sofa.boot.util.StringUtils;
+import com.alipay.sofa.rpc.common.MockMode;
+import com.alipay.sofa.rpc.config.ConsumerConfig;
+import org.springframework.beans.factory.annotation.Value;
+
+/**
+ * @author zhaowang
+ * @version : ConsumerMockProcessor.java, v 0.1 2020年03月11日 11:24 上午 zhaowang Exp $
+ */
+public class ConsumerMockProcessor implements ConsumerConfigProcessor {
+
+    public static final String MOCK_URL = "mockUrl";
+    @Value("${com.alipay.sofa.rpc.mock-url}")
+    private String             mockUrl;
+
+    @Override
+    public void processorConsumer(ConsumerConfig consumerConfig) {
+        String mockMode = consumerConfig.getMockMode();
+        if (StringUtils.hasText(mockUrl)
+            && (!StringUtils.hasText(mockMode) || MockMode.REMOTE.equals(mockMode))) {
+            String originMockUrl = consumerConfig.getParameter(MOCK_URL);
+            if (!StringUtils.hasText(originMockUrl)) {
+                consumerConfig.setMockMode(MockMode.REMOTE);
+                consumerConfig.setParameter(MOCK_URL, mockUrl);
+            }
+        }
+    }
+
+    public String getMockUrl() {
+        return mockUrl;
+    }
+
+    public void setMockUrl(String mockUrl) {
+        this.mockUrl = mockUrl;
+    }
+}

--- a/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/main/java/com/alipay/sofa/rpc/boot/runtime/adapter/processor/DynamicConfigProcessor.java
+++ b/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/main/java/com/alipay/sofa/rpc/boot/runtime/adapter/processor/DynamicConfigProcessor.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.rpc.boot.runtime.adapter.processor;
+
+import com.alipay.sofa.rpc.common.utils.StringUtils;
+import com.alipay.sofa.rpc.config.AbstractInterfaceConfig;
+import com.alipay.sofa.rpc.config.ConsumerConfig;
+import com.alipay.sofa.rpc.config.ProviderConfig;
+import com.alipay.sofa.rpc.dynamic.DynamicConfigKeys;
+import org.springframework.beans.factory.annotation.Value;
+
+/**
+ * @author zhaowang
+ * @version : DynamicConfigProcessor.java, v 0.1 2020年03月11日 11:55 上午 zhaowang Exp $
+ */
+public class DynamicConfigProcessor implements ConsumerConfigProcessor, ProviderConfigProcessor {
+
+    @Value("${com.alipay.sofa.rpc.dynamic-config}")
+    private String dynamicConfig;
+
+    @Override
+    public void processorConsumer(ConsumerConfig consumerConfig) {
+        setDynamicConfig(consumerConfig);
+    }
+
+    @Override
+    public void processorProvider(ProviderConfig providerConfig) {
+        setDynamicConfig(providerConfig);
+    }
+
+    private void setDynamicConfig(AbstractInterfaceConfig config) {
+        String configAlias = config.getParameter(DynamicConfigKeys.DYNAMIC_ALIAS);
+        if (StringUtils.isBlank(configAlias) && StringUtils.isNotBlank(dynamicConfig)) {
+            config.setParameter(DynamicConfigKeys.DYNAMIC_ALIAS, dynamicConfig);
+        }
+    }
+
+    public String getDynamicConfig() {
+        return dynamicConfig;
+    }
+
+    public void setDynamicConfig(String dynamicConfig) {
+        this.dynamicConfig = dynamicConfig;
+    }
+}

--- a/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/main/java/com/alipay/sofa/rpc/boot/runtime/adapter/processor/ProcessorContainer.java
+++ b/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/main/java/com/alipay/sofa/rpc/boot/runtime/adapter/processor/ProcessorContainer.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.rpc.boot.runtime.adapter.processor;
+
+import com.alipay.sofa.rpc.common.utils.CommonUtils;
+import com.alipay.sofa.rpc.config.ConsumerConfig;
+import com.alipay.sofa.rpc.config.ProviderConfig;
+
+import java.util.List;
+
+/**
+ * @author zhaowang
+ * @version : ProcessorContainer.java, v 0.1 2020年03月11日 10:28 上午 zhaowang Exp $
+ */
+public class ProcessorContainer {
+
+    private List<ProviderConfigProcessor> providerProcessors;
+
+    private List<ConsumerConfigProcessor> consumerProcessors;
+
+    public ProcessorContainer(List<ProviderConfigProcessor> providerProcessors,
+                              List<ConsumerConfigProcessor> consumerProcessors) {
+        this.providerProcessors = providerProcessors;
+        this.consumerProcessors = consumerProcessors;
+    }
+
+    public void processorConsumer(ConsumerConfig consumerConfig) {
+        if (CommonUtils.isNotEmpty(consumerProcessors)) {
+            for (ConsumerConfigProcessor consumerProcessor : consumerProcessors) {
+                consumerProcessor.processorConsumer(consumerConfig);
+            }
+        }
+    }
+
+    public void processorProvider(ProviderConfig providerConfig) {
+        if (CommonUtils.isNotEmpty(providerProcessors)) {
+            for (ProviderConfigProcessor providerProcessor : providerProcessors) {
+                providerProcessor.processorProvider(providerConfig);
+            }
+        }
+
+    }
+
+}

--- a/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/main/java/com/alipay/sofa/rpc/boot/runtime/adapter/processor/ProviderConfigProcessor.java
+++ b/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/main/java/com/alipay/sofa/rpc/boot/runtime/adapter/processor/ProviderConfigProcessor.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.rpc.boot.runtime.adapter.processor;
+
+import com.alipay.sofa.rpc.config.ProviderConfig;
+
+/**
+ * @author zhaowang
+ * @version : ProviderConfigProcessor.java, v 0.1 2020年03月11日 10:34 上午 zhaowang Exp $
+ */
+public interface ProviderConfigProcessor {
+
+    void processorProvider(ProviderConfig providerConfig);
+
+}

--- a/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/main/java/com/alipay/sofa/rpc/boot/runtime/binding/RpcBindingXmlConstants.java
+++ b/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/main/java/com/alipay/sofa/rpc/boot/runtime/binding/RpcBindingXmlConstants.java
@@ -52,6 +52,8 @@ public class RpcBindingXmlConstants {
     public static final String TAG_CHECK             = "check";
     public static final String TAG_PARAMETER_KEY     = "key";
     public static final String TAG_PARAMETER_VALUE   = "value";
+    public static final String TAG_MOCK_MODE         = "mock-mode";
+    public static final String TAG_MOCK_BEAN         = "mock-bean";
 
     public static final String TAG_NAME              = "name";
 

--- a/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/main/java/com/alipay/sofa/rpc/boot/runtime/converter/RpcBindingConverter.java
+++ b/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/main/java/com/alipay/sofa/rpc/boot/runtime/converter/RpcBindingConverter.java
@@ -230,6 +230,8 @@ public abstract class RpcBindingConverter implements BindingConverter<RpcBinding
         Boolean check = SofaBootRpcParserUtil.parseBoolean(element
             .getAttribute(RpcBindingXmlConstants.TAG_CHECK));
         String registryAlias = element.getAttribute(RpcBindingXmlConstants.TAG_REGISTRY);
+        String mockMode = element.getAttribute(RpcBindingXmlConstants.TAG_MOCK_MODE);
+        String mockBean = element.getAttribute(RpcBindingXmlConstants.TAG_MOCK_BEAN);
 
         String serialization = element.getAttribute(RpcBindingXmlConstants.TAG_SERIALIZE_TYPE);
         if (timeout != null) {
@@ -284,6 +286,12 @@ public abstract class RpcBindingConverter implements BindingConverter<RpcBinding
         if (StringUtils.hasText(registryAlias)) {
             String[] registrys = registryAlias.split(",");
             param.setRegistrys(Arrays.asList(registrys));
+        }
+        if (StringUtils.hasText(mockMode)) {
+            param.setMockMode(mockMode);
+        }
+        if (StringUtils.hasText(mockBean)) {
+            param.setMockBean(mockBean);
         }
     }
 
@@ -503,6 +511,13 @@ public abstract class RpcBindingConverter implements BindingConverter<RpcBinding
         if (StringUtils.hasText(sofaReferenceBindingAnnotation.loadBalancer())) {
             bindingParam.setLoadBalancer(sofaReferenceBindingAnnotation.loadBalancer());
         }
+        if (StringUtils.hasText(sofaReferenceBindingAnnotation.mockMode())) {
+            bindingParam.setMockMode(sofaReferenceBindingAnnotation.mockMode());
+        }
+        if (StringUtils.hasText(sofaReferenceBindingAnnotation.mockBean())) {
+            bindingParam.setMockBean(sofaReferenceBindingAnnotation.mockBean());
+        }
+
         bindingParam.setType(sofaReferenceBindingAnnotation.invokeType());
 
         ApplicationContext applicationContext = bindingConverterContext.getApplicationContext();

--- a/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/main/java/com/alipay/sofa/rpc/boot/runtime/param/RpcBindingParam.java
+++ b/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/main/java/com/alipay/sofa/rpc/boot/runtime/param/RpcBindingParam.java
@@ -81,6 +81,10 @@ public abstract class RpcBindingParam implements BindingParam {
 
     private Integer                      repeatReferLimit;
 
+    protected String                     mockMode;
+
+    protected String                     mockBean;
+
     /**
      * Getter method for property <tt>timeout</tt>.
      *
@@ -545,4 +549,19 @@ public abstract class RpcBindingParam implements BindingParam {
         this.repeatReferLimit = repeatReferLimit;
     }
 
+    public String getMockMode() {
+        return mockMode;
+    }
+
+    public void setMockMode(String mockMode) {
+        this.mockMode = mockMode;
+    }
+
+    public String getMockBean() {
+        return mockBean;
+    }
+
+    public void setMockBean(String mockBean) {
+        this.mockBean = mockBean;
+    }
 }

--- a/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/test/java/com/alipay/sofa/rpc/boot/test/SofaRpcTestAutoConfiguration.java
+++ b/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/test/java/com/alipay/sofa/rpc/boot/test/SofaRpcTestAutoConfiguration.java
@@ -37,6 +37,11 @@ import com.alipay.sofa.rpc.boot.context.SofaBootRpcStartListener;
 import com.alipay.sofa.rpc.boot.health.RpcAfterHealthCheckCallback;
 import com.alipay.sofa.rpc.boot.runtime.adapter.helper.ConsumerConfigHelper;
 import com.alipay.sofa.rpc.boot.runtime.adapter.helper.ProviderConfigHelper;
+import com.alipay.sofa.rpc.boot.runtime.adapter.processor.ConsumerConfigProcessor;
+import com.alipay.sofa.rpc.boot.runtime.adapter.processor.ConsumerMockProcessor;
+import com.alipay.sofa.rpc.boot.runtime.adapter.processor.DynamicConfigProcessor;
+import com.alipay.sofa.rpc.boot.runtime.adapter.processor.ProcessorContainer;
+import com.alipay.sofa.rpc.boot.runtime.adapter.processor.ProviderConfigProcessor;
 import com.alipay.sofa.rpc.boot.swagger.SwaggerServiceApplicationListener;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -169,5 +174,23 @@ public class SofaRpcTestAutoConfiguration {
         public RpcAfterHealthCheckCallback rpcAfterHealthCheckCallback() {
             return new RpcAfterHealthCheckCallback();
         }
+    }
+
+    @Bean
+    public ProcessorContainer processorContainer(List<ProviderConfigProcessor> providerConfigProcessors,
+                                                 List<ConsumerConfigProcessor> consumerConfigProcessors) {
+        return new ProcessorContainer(providerConfigProcessors, consumerConfigProcessors);
+    }
+
+    @Bean
+    @ConditionalOnProperty(name = "com.alipay.sofa.rpc.mock-url")
+    public ConsumerMockProcessor consumerMockProcessor() {
+        return new ConsumerMockProcessor();
+    }
+
+    @Bean
+    @ConditionalOnProperty(name = "com.alipay.sofa.rpc.dynamic-config")
+    public DynamicConfigProcessor dynamicConfigProcessor() {
+        return new DynamicConfigProcessor();
     }
 }

--- a/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/test/java/com/alipay/sofa/rpc/boot/test/mock/HttpMockServer.java
+++ b/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/test/java/com/alipay/sofa/rpc/boot/test/mock/HttpMockServer.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.rpc.boot.test.mock;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.InetSocketAddress;
+
+/**
+ * @author zhaowang
+ * @version : HttpMockServer.java, v 0.1 2020年03月10日 9:53 下午 zhaowang Exp $
+ */
+public class HttpMockServer {
+
+    static HttpServer httpServer;
+
+    /**
+     * init first
+     *
+     * @param port
+     * @return
+     */
+    public static boolean initSever(int port) {
+
+        if (httpServer != null) {
+
+            return false;
+        }
+
+        try {
+            httpServer = HttpServer.create(new InetSocketAddress(port), 0);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        return true;
+    }
+
+    /**
+     * add mock
+     *
+     * @return
+     */
+    public static boolean addMockPath(String path, final String responseJson) {
+        httpServer.createContext(path, new HttpHandler() {
+            public void handle(HttpExchange exchange) throws IOException {
+                byte[] response = responseJson.getBytes();
+                exchange.sendResponseHeaders(HttpURLConnection.HTTP_OK, response.length);
+                exchange.getResponseBody().write(response);
+                exchange.close();
+            }
+        });
+
+        return true;
+
+    }
+
+    /**
+     * start server
+     *
+     * @return
+     */
+    public static boolean start() {
+        if (httpServer != null) {
+            httpServer.start();
+        } else {
+            throw new RuntimeException("please init server first");
+        }
+
+        return true;
+
+    }
+
+    /**
+     * stop server
+     *
+     * @return
+     */
+    public static boolean stop() {
+        if (httpServer != null) {
+            httpServer.stop(0);
+            httpServer = null;
+        } else {
+            throw new RuntimeException("server has been stopped");
+        }
+        return true;
+
+    }
+
+}

--- a/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/test/java/com/alipay/sofa/rpc/boot/test/mock/MockBeanConfigTest.java
+++ b/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/test/java/com/alipay/sofa/rpc/boot/test/mock/MockBeanConfigTest.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.rpc.boot.test.mock;
+
+import com.alipay.sofa.rpc.boot.runtime.adapter.helper.ConsumerConfigHelper;
+import com.alipay.sofa.rpc.boot.runtime.binding.BoltBinding;
+import com.alipay.sofa.rpc.boot.runtime.binding.RpcBinding;
+import com.alipay.sofa.rpc.boot.runtime.param.BoltBindingParam;
+import com.alipay.sofa.rpc.boot.runtime.param.RpcBindingParam;
+import com.alipay.sofa.rpc.boot.test.bean.invoke.HelloSyncService;
+import com.alipay.sofa.rpc.common.MockMode;
+import com.alipay.sofa.rpc.common.json.JSON;
+import com.alipay.sofa.runtime.api.annotation.SofaParameter;
+import com.alipay.sofa.runtime.api.annotation.SofaReference;
+import com.alipay.sofa.runtime.api.annotation.SofaReferenceBinding;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.ImportResource;
+import org.springframework.test.context.junit4.SpringRunner;
+
+/**
+ * @author zhaowang
+ * @version : MockBeanConfigTest.java, v 0.1 2020年03月10日 9:12 下午 zhaowang Exp $
+ */
+@SpringBootApplication
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@ImportResource("/spring/test_only_mock_bean.xml")
+public class MockBeanConfigTest {
+
+    @SofaReference(binding = @SofaReferenceBinding(bindingType = "bolt", mockMode = MockMode.LOCAL, mockBean = "mockHello"))
+    private HelloSyncService     helloSyncService;
+
+    @Autowired
+    private ConsumerConfigHelper consumerConfigHelper;
+
+    @Test
+    public void testLocalMock() {
+        String s = helloSyncService.saySync("mock");
+        Assert.assertEquals("mock", s);
+    }
+
+    @Test
+    public void testEmptyMockBean() {
+        RpcBindingParam rpcBindingParam = new BoltBindingParam();
+
+        RpcBinding rpcBinding = new BoltBinding(rpcBindingParam, null, true);
+        try {
+            consumerConfigHelper.getMockRef(rpcBinding, null);
+            Assert.fail();
+        } catch (IllegalArgumentException e) {
+            // success;
+        }
+    }
+
+    @SofaReference(binding = @SofaReferenceBinding(bindingType = "bolt", mockMode = MockMode.REMOTE, parameters = @SofaParameter(key = "mockUrl", value = "http://127.0.0.1:1235/")))
+    private HelloSyncService remoteMock;
+
+    @Test
+    public void testRemote() {
+
+        HttpMockServer.initSever(1235);
+        HttpMockServer.addMockPath("/", JSON.toJSONString("mockJson"));
+        HttpMockServer.start();
+
+        Assert.assertEquals("mockJson", remoteMock.saySync(("xx")));
+
+        HttpMockServer.stop();
+    }
+
+}

--- a/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/test/java/com/alipay/sofa/rpc/boot/test/mock/MockBeanConfigTest.java
+++ b/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/test/java/com/alipay/sofa/rpc/boot/test/mock/MockBeanConfigTest.java
@@ -16,6 +16,7 @@
  */
 package com.alipay.sofa.rpc.boot.test.mock;
 
+import com.alipay.sofa.rpc.boot.config.SofaBootRpcProperties;
 import com.alipay.sofa.rpc.boot.runtime.adapter.helper.ConsumerConfigHelper;
 import com.alipay.sofa.rpc.boot.runtime.binding.BoltBinding;
 import com.alipay.sofa.rpc.boot.runtime.binding.RpcBinding;
@@ -34,6 +35,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.ImportResource;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
 /**
@@ -44,6 +46,8 @@ import org.springframework.test.context.junit4.SpringRunner;
 @RunWith(SpringRunner.class)
 @SpringBootTest
 @ImportResource("/spring/test_only_mock_bean.xml")
+@TestPropertySource(properties = { SofaBootRpcProperties.PREFIX
+                                   + ".consumer.repeated.reference.limit=10", })
 public class MockBeanConfigTest {
 
     @SofaReference(binding = @SofaReferenceBinding(bindingType = "bolt", mockMode = MockMode.LOCAL, mockBean = "mockHello"))

--- a/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/test/java/com/alipay/sofa/rpc/boot/test/mock/xml/XmlConfigTest.java
+++ b/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/test/java/com/alipay/sofa/rpc/boot/test/mock/xml/XmlConfigTest.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.rpc.boot.test.mock.xml;
+
+import com.alipay.sofa.rpc.boot.test.bean.invoke.HelloSyncService;
+import com.alipay.sofa.rpc.boot.test.mock.HttpMockServer;
+import com.alipay.sofa.rpc.common.json.JSON;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.ImportResource;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import javax.annotation.Resource;
+
+/**
+ * @author zhaowang
+ * @version : XmlConfigTest.java, v 0.1 2020年03月10日 11:40 下午 zhaowang Exp $
+ */
+@SpringBootApplication
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@ImportResource("/spring/test_only_mock.xml")
+public class XmlConfigTest {
+
+    @Resource(name = "xmlLocalMock")
+    private HelloSyncService xmlLocalMock;
+
+    @Test
+    public void testXmlLocalMock() {
+        String xml = xmlLocalMock.saySync("xml");
+        Assert.assertEquals("xml", xml);
+    }
+
+    @Resource(name = "xmlRemoteMock")
+    private HelloSyncService xmlRemoteMock;
+
+    @Test
+    public void testXmlRemote() {
+
+        HttpMockServer.initSever(1236);
+        HttpMockServer.addMockPath("/", JSON.toJSONString("mockJson"));
+        HttpMockServer.start();
+
+        Assert.assertEquals("mockJson", xmlRemoteMock.saySync(("xx")));
+
+        HttpMockServer.stop();
+    }
+}

--- a/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/test/java/com/alipay/sofa/rpc/boot/test/readiness/ReadinessTest.java
+++ b/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/test/java/com/alipay/sofa/rpc/boot/test/readiness/ReadinessTest.java
@@ -54,7 +54,7 @@ public class ReadinessTest extends ActivelyDestroyTest {
     @Test
     public void testCannotFoundAddress() throws InterruptedException {
         thrown.expect(SofaRouteException.class);
-        thrown.expectMessage("RPC-02306");
+        thrown.expectMessage("RPC-020060001");
         TimeUnit.SECONDS.sleep(1);
         Assert.assertEquals("hi World!", sampleFacade.sayHi("World"));
     }

--- a/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/test/java/com/alipay/sofa/rpc/boot/test/runtime/adapter/processor/ConsumerMockProcessorTest.java
+++ b/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/test/java/com/alipay/sofa/rpc/boot/test/runtime/adapter/processor/ConsumerMockProcessorTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.rpc.boot.test.runtime.adapter.processor;
+
+import com.alipay.sofa.boot.util.StringUtils;
+import com.alipay.sofa.rpc.boot.runtime.adapter.processor.ConsumerMockProcessor;
+import com.alipay.sofa.rpc.common.MockMode;
+import com.alipay.sofa.rpc.config.ConsumerConfig;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author zhaowang
+ * @version : ConsumerMockProcessorTest.java, v 0.1 2020年03月11日 2:32 下午 zhaowang Exp $
+ */
+public class ConsumerMockProcessorTest {
+
+    public static final String    MOCK_URL  = "mock";
+    private ConsumerMockProcessor processor = new ConsumerMockProcessor();
+
+    @Before
+    public void before() {
+        processor.setMockUrl(MOCK_URL);
+    }
+
+    @Test
+    public void testProcessor() {
+        ConsumerConfig consumerConfig = new ConsumerConfig();
+        processor.processorConsumer(consumerConfig);
+        Assert.assertEquals(MOCK_URL, consumerConfig.getParameter(ConsumerMockProcessor.MOCK_URL));
+        Assert.assertEquals(MockMode.REMOTE, consumerConfig.getMockMode());
+
+        processor.setMockUrl("");
+        ConsumerConfig consumerConfig2 = new ConsumerConfig();
+        processor.processorConsumer(consumerConfig2);
+        Assert.assertFalse(StringUtils.hasText(consumerConfig2.getMockMode()));
+        Assert.assertFalse(StringUtils.hasText(consumerConfig2
+            .getParameter(ConsumerMockProcessor.MOCK_URL)));
+    }
+
+    @Test
+    public void testMockSet() {
+        ConsumerConfig consumerConfig = new ConsumerConfig();
+        consumerConfig.setMockMode(MockMode.LOCAL);
+        processor.processorConsumer(consumerConfig);
+        Assert.assertFalse(StringUtils.hasText(consumerConfig
+            .getParameter(ConsumerMockProcessor.MOCK_URL)));
+        Assert.assertEquals(MockMode.LOCAL, consumerConfig.getMockMode());
+
+        consumerConfig = new ConsumerConfig();
+        consumerConfig.setMockMode(MockMode.REMOTE);
+        consumerConfig.setParameter(ConsumerMockProcessor.MOCK_URL, "another");
+        processor.processorConsumer(consumerConfig);
+        Assert.assertEquals("another", consumerConfig.getParameter(ConsumerMockProcessor.MOCK_URL));
+        Assert.assertEquals(MockMode.REMOTE, consumerConfig.getMockMode());
+    }
+
+}

--- a/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/test/java/com/alipay/sofa/rpc/boot/test/runtime/adapter/processor/DynamicConfigProcessorTest.java
+++ b/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/test/java/com/alipay/sofa/rpc/boot/test/runtime/adapter/processor/DynamicConfigProcessorTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.rpc.boot.test.runtime.adapter.processor;
+
+import com.alipay.sofa.boot.util.StringUtils;
+import com.alipay.sofa.rpc.boot.runtime.adapter.processor.DynamicConfigProcessor;
+import com.alipay.sofa.rpc.config.ConsumerConfig;
+import com.alipay.sofa.rpc.config.ProviderConfig;
+import com.alipay.sofa.rpc.dynamic.DynamicConfigKeys;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author zhaowang
+ * @version : DynamicConfigProcessorTest.java, v 0.1 2020年03月11日 3:21 下午 zhaowang Exp $
+ */
+public class DynamicConfigProcessorTest {
+
+    public static final String     CONFIG    = "config";
+    public static final String     ANOTHER   = "another";
+    private DynamicConfigProcessor processor = new DynamicConfigProcessor();
+
+    @Test
+    public void test() {
+        processor.setDynamicConfig(CONFIG);
+
+        ConsumerConfig consumerConfig = new ConsumerConfig();
+        processor.processorConsumer(consumerConfig);
+        Assert.assertEquals(CONFIG, consumerConfig.getParameter(DynamicConfigKeys.DYNAMIC_ALIAS));
+
+        ProviderConfig providerConfig = new ProviderConfig();
+        processor.processorProvider(providerConfig);
+        Assert.assertEquals(CONFIG, providerConfig.getParameter(DynamicConfigKeys.DYNAMIC_ALIAS));
+
+        consumerConfig = new ConsumerConfig();
+        consumerConfig.setParameter(DynamicConfigKeys.DYNAMIC_ALIAS, ANOTHER);
+        processor.processorConsumer(consumerConfig);
+        Assert.assertEquals(ANOTHER, consumerConfig.getParameter(DynamicConfigKeys.DYNAMIC_ALIAS));
+
+        providerConfig = new ProviderConfig();
+        providerConfig.setParameter(DynamicConfigKeys.DYNAMIC_ALIAS, ANOTHER);
+        processor.processorProvider(providerConfig);
+        Assert.assertEquals(ANOTHER, providerConfig.getParameter(DynamicConfigKeys.DYNAMIC_ALIAS));
+
+        processor.setDynamicConfig("");
+        consumerConfig = new ConsumerConfig();
+        processor.processorConsumer(consumerConfig);
+        Assert.assertFalse(StringUtils.hasText(consumerConfig
+            .getParameter(DynamicConfigKeys.DYNAMIC_ALIAS)));
+
+        providerConfig = new ProviderConfig();
+        processor.processorProvider(providerConfig);
+        Assert.assertFalse(StringUtils.hasText(providerConfig
+            .getParameter(DynamicConfigKeys.DYNAMIC_ALIAS)));
+
+    }
+
+}

--- a/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/test/java/com/alipay/sofa/rpc/boot/test/runtime/adapter/processor/ProcessorAutoConfigTest.java
+++ b/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/test/java/com/alipay/sofa/rpc/boot/test/runtime/adapter/processor/ProcessorAutoConfigTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.rpc.boot.test.runtime.adapter.processor;
+
+import com.alipay.sofa.rpc.boot.runtime.adapter.processor.ConsumerMockProcessor;
+import com.alipay.sofa.rpc.boot.runtime.adapter.processor.DynamicConfigProcessor;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+
+/**
+ * @author zhaowang
+ * @version : ProcessorAutoConfigTest.java, v 0.1 2020年03月11日 3:49 下午 zhaowang Exp $
+ */
+@SpringBootTest
+@SpringBootApplication
+@RunWith(SpringRunner.class)
+@TestPropertySource(properties = { "com.alipay.sofa.rpc.dynamic-config=apollo",
+                                  "com.alipay.sofa.rpc.mock-url=abc", })
+public class ProcessorAutoConfigTest {
+
+    @Autowired
+    private DynamicConfigProcessor dynamicConfigProcessor;
+
+    @Autowired
+    private ConsumerMockProcessor  consumerMockProcessor;
+
+    @Test
+    public void testProperty() {
+        Assert.assertEquals("apollo", dynamicConfigProcessor.getDynamicConfig());
+        Assert.assertEquals("abc", consumerMockProcessor.getMockUrl());
+
+    }
+}

--- a/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/test/resources/spring/test_only_mock.xml
+++ b/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/test/resources/spring/test_only_mock.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:sofa="http://sofastack.io/schema/sofaboot"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+            http://sofastack.io/schema/sofaboot   http://sofastack.io/schema/sofaboot.xsd">
+
+    <bean id="mockHello" class="com.alipay.sofa.rpc.boot.test.bean.invoke.HelloSyncServiceImpl"/>
+
+    <sofa:reference id="xmlLocalMock" interface="com.alipay.sofa.rpc.boot.test.bean.invoke.HelloSyncService" repeatReferLimit="10">
+        <sofa:binding.bolt>
+            <sofa:global-attrs mock-bean="mockHello" mock-mode="local"/>
+        </sofa:binding.bolt>
+    </sofa:reference>
+
+    <sofa:reference id="xmlRemoteMock" interface="com.alipay.sofa.rpc.boot.test.bean.invoke.HelloSyncService" repeatReferLimit="10">
+        <sofa:binding.bolt>
+            <sofa:global-attrs mock-mode="remote"/>
+            <sofa:parameter key="mockUrl" value="http://127.0.0.1:1236/"/>
+        </sofa:binding.bolt>
+    </sofa:reference>
+</beans>

--- a/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/test/resources/spring/test_only_mock_bean.xml
+++ b/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/test/resources/spring/test_only_mock_bean.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:sofa="http://sofastack.io/schema/sofaboot"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+            http://sofastack.io/schema/sofaboot   http://sofastack.io/schema/sofaboot.xsd">
+
+    <bean id="mockHello" class="com.alipay.sofa.rpc.boot.test.bean.invoke.HelloSyncServiceImpl"/>
+</beans>

--- a/sofa-boot-project/sofa-boot-core/runtime-sofa-boot/src/main/java/com/alipay/sofa/runtime/api/annotation/SofaReferenceBinding.java
+++ b/sofa-boot-project/sofa-boot-core/runtime-sofa-boot/src/main/java/com/alipay/sofa/runtime/api/annotation/SofaReferenceBinding.java
@@ -145,4 +145,16 @@ public @interface SofaReferenceBinding {
      * @since 2.6.4
      */
     SofaMethod[] methodInfos() default {};
+
+    /**
+     * mock mode of reference
+     * @return "local", "remote" or empty
+     */
+    String mockMode() default "";
+
+    /**
+     * get mock from spring beans
+     * @return bean name
+     */
+    String mockBean() default "";
 }

--- a/sofa-boot-project/sofa-boot/src/main/resources/com/alipay/sofa/boot/spring/namespace/schema/rpc.xsd
+++ b/sofa-boot-project/sofa-boot/src/main/resources/com/alipay/sofa/boot/spring/namespace/schema/rpc.xsd
@@ -109,6 +109,8 @@
         <xsd:attribute name="check" type="xsd:boolean" use="optional"/>
         <xsd:attribute name="registry" type="xsd:string" use="optional"/>
         <xsd:attribute name="serialize-type" type="xsd:string" use="optional"/>
+        <xsd:attribute name="mock-mode" type="xsd:string" use="optional"/>
+        <xsd:attribute name="mock-bean" type="xsd:string" use="optional"/>
     </xsd:complexType>
 
     <!-- method in service binding.bolt -->

--- a/sofa-boot-project/sofaboot-dependencies/pom.xml
+++ b/sofa-boot-project/sofaboot-dependencies/pom.xml
@@ -30,7 +30,7 @@
 
         <!--core-->
         <tracer.core.version>3.0.8</tracer.core.version>
-        <rpc.core.version>5.6.4</rpc.core.version>
+        <rpc.core.version>5.6.5-SNAPSHOT</rpc.core.version>
 
         <!--2rd lib dependency-->
         <sofa.common.tools.version>1.0.21</sofa.common.tools.version>

--- a/sofa-boot-project/sofaboot-dependencies/pom.xml
+++ b/sofa-boot-project/sofaboot-dependencies/pom.xml
@@ -30,7 +30,7 @@
 
         <!--core-->
         <tracer.core.version>3.0.8</tracer.core.version>
-        <rpc.core.version>5.6.5-SNAPSHOT</rpc.core.version>
+        <rpc.core.version>5.6.5</rpc.core.version>
 
         <!--2rd lib dependency-->
         <sofa.common.tools.version>1.0.21</sofa.common.tools.version>


### PR DESCRIPTION
Support use xml or annotation to set bolt mock.

For example:
```xml 
  <sofa:reference id="xmlLocalMock" interface="com.alipay.sofa.rpc.boot.test.bean.invoke.HelloSyncService" repeatReferLimit="10">
        <sofa:binding.bolt>
            <sofa:global-attrs mock-bean="mockHello" mock-mode="local"/>
        </sofa:binding.bolt>
    </sofa:reference>

    <sofa:reference id="xmlRemoteMock" interface="com.alipay.sofa.rpc.boot.test.bean.invoke.HelloSyncService" repeatReferLimit="10">
        <sofa:binding.bolt>
            <sofa:global-attrs mock-mode="remote"/>
            <sofa:parameter key="mockUrl" value="http://127.0.0.1:1236/"/>
        </sofa:binding.bolt>
    </sofa:reference>
```

and 
```java

@SofaReference(binding = @SofaReferenceBinding(bindingType = "bolt", mockMode = MockMode.LOCAL, mockBean = "mockHello"))
private HelloSyncService     helloSyncService;

@SofaReference(binding = @SofaReferenceBinding(bindingType = "bolt", mockMode = MockMode.REMOTE, parameters = @SofaParameter(key = "mockUrl", value = "http://127.0.0.1:1235/")))
private HelloSyncService remoteMock;
```