### PR TITLE
feat: support add rpc extension by creating a bean

### DIFF
--- a/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/rpc/SofaRpcAutoConfiguration.java
+++ b/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/rpc/SofaRpcAutoConfiguration.java
@@ -35,6 +35,7 @@ import com.alipay.sofa.rpc.boot.container.ServerConfigContainer;
 import com.alipay.sofa.rpc.boot.context.ApplicationContextClosedListener;
 import com.alipay.sofa.rpc.boot.context.ApplicationContextRefreshedListener;
 import com.alipay.sofa.rpc.boot.context.SofaBootRpcStartListener;
+import com.alipay.sofa.rpc.boot.ext.RpcExtensionBeanPostProcessor;
 import com.alipay.sofa.rpc.boot.health.RpcAfterHealthCheckCallback;
 import com.alipay.sofa.rpc.boot.runtime.adapter.helper.ConsumerConfigHelper;
 import com.alipay.sofa.rpc.boot.runtime.adapter.helper.ProviderConfigHelper;
@@ -268,5 +269,11 @@ public class SofaRpcAutoConfiguration {
     @ConditionalOnProperty(name = "com.alipay.sofa.rpc.dynamic-config")
     public DynamicConfigProcessor dynamicConfigProcessor() {
         return new DynamicConfigProcessor();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public RpcExtensionBeanPostProcessor rpcExtensionBeanPostProcessor() {
+        return new RpcExtensionBeanPostProcessor();
     }
 }

--- a/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/rpc/SofaRpcAutoConfiguration.java
+++ b/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/rpc/SofaRpcAutoConfiguration.java
@@ -18,6 +18,7 @@ package com.alipay.sofa.boot.autoconfigure.rpc;
 
 import com.alipay.sofa.healthcheck.startup.ReadinessCheckCallback;
 import com.alipay.sofa.rpc.boot.config.ConsulConfigurator;
+import com.alipay.sofa.rpc.boot.config.ExtensionProperties;
 import com.alipay.sofa.rpc.boot.config.FaultToleranceConfigurator;
 import com.alipay.sofa.rpc.boot.config.LocalFileConfigurator;
 import com.alipay.sofa.rpc.boot.config.MeshConfigurator;
@@ -35,6 +36,7 @@ import com.alipay.sofa.rpc.boot.container.ServerConfigContainer;
 import com.alipay.sofa.rpc.boot.context.ApplicationContextClosedListener;
 import com.alipay.sofa.rpc.boot.context.ApplicationContextRefreshedListener;
 import com.alipay.sofa.rpc.boot.context.SofaBootRpcStartListener;
+import com.alipay.sofa.rpc.boot.ext.ExtensionConfigProcessor;
 import com.alipay.sofa.rpc.boot.ext.RpcExtensionBeanPostProcessor;
 import com.alipay.sofa.rpc.boot.health.RpcAfterHealthCheckCallback;
 import com.alipay.sofa.rpc.boot.runtime.adapter.helper.ConsumerConfigHelper;
@@ -71,7 +73,7 @@ import java.util.Map;
  * @author <a href="mailto:lw111072@antfin.com">LiWei</a>
  */
 @Configuration
-@EnableConfigurationProperties(SofaBootRpcProperties.class)
+@EnableConfigurationProperties({ SofaBootRpcProperties.class, ExtensionProperties.class })
 @ConditionalOnClass(SofaBootRpcProperties.class)
 public class SofaRpcAutoConfiguration {
     @Bean
@@ -275,5 +277,11 @@ public class SofaRpcAutoConfiguration {
     @ConditionalOnMissingBean
     public RpcExtensionBeanPostProcessor rpcExtensionBeanPostProcessor() {
         return new RpcExtensionBeanPostProcessor();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public ExtensionConfigProcessor extensionConfigProcessor() {
+        return new ExtensionConfigProcessor();
     }
 }

--- a/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/main/java/com/alipay/sofa/rpc/boot/config/ExtensionProperties.java
+++ b/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/main/java/com/alipay/sofa/rpc/boot/config/ExtensionProperties.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.rpc.boot.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * @author zhaowang
+ * @version : ExtensionProperties.java, v 0.1 2020年05月09日 2:13 下午 zhaowang Exp $
+ */
+@ConfigurationProperties(ExtensionProperties.PREFIX)
+public class ExtensionProperties {
+    public static final String PREFIX = "com.alipay.sofa.rpc.ext";
+
+    private String             addressHolder;
+
+    private String             cluster;
+
+    private String             connectionHolder;
+
+    private String             loadBalancer;
+
+    private String             proxy;
+
+    public String getProxy() {
+        return proxy;
+    }
+
+    public void setProxy(String proxy) {
+        this.proxy = proxy;
+    }
+
+    public String getLoadBalancer() {
+        return loadBalancer;
+    }
+
+    public void setLoadBalancer(String loadBalancer) {
+        this.loadBalancer = loadBalancer;
+    }
+
+    public String getConnectionHolder() {
+        return connectionHolder;
+    }
+
+    public void setConnectionHolder(String connectionHolder) {
+        this.connectionHolder = connectionHolder;
+    }
+
+    public String getCluster() {
+        return cluster;
+    }
+
+    public void setCluster(String cluster) {
+        this.cluster = cluster;
+    }
+
+    public String getAddressHolder() {
+        return addressHolder;
+    }
+
+    public void setAddressHolder(String addressHolder) {
+        this.addressHolder = addressHolder;
+    }
+
+}

--- a/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/main/java/com/alipay/sofa/rpc/boot/ext/ExtensionConfigProcessor.java
+++ b/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/main/java/com/alipay/sofa/rpc/boot/ext/ExtensionConfigProcessor.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.rpc.boot.ext;
+
+import com.alipay.sofa.rpc.boot.config.ExtensionProperties;
+import com.alipay.sofa.rpc.boot.runtime.adapter.processor.ConsumerConfigProcessor;
+import com.alipay.sofa.rpc.boot.runtime.adapter.processor.ProviderConfigProcessor;
+import com.alipay.sofa.rpc.common.utils.StringUtils;
+import com.alipay.sofa.rpc.config.ConsumerConfig;
+import com.alipay.sofa.rpc.config.ProviderConfig;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * @author zhaowang
+ * @version : ExtensionConfigProcessor.java, v 0.1 2020年05月09日 2:12 下午 zhaowang Exp $
+ */
+public class ExtensionConfigProcessor implements ConsumerConfigProcessor, ProviderConfigProcessor {
+
+    @Autowired
+    private ExtensionProperties properties;
+
+    @Override
+    public void processorConsumer(ConsumerConfig consumerConfig) {
+        String addressHolder = properties.getAddressHolder();
+        if (StringUtils.isNotBlank(addressHolder)) {
+            consumerConfig.setAddressHolder(addressHolder);
+        }
+
+        String cluster = properties.getCluster();
+        if (StringUtils.isNotBlank(cluster)) {
+            consumerConfig.setCluster(cluster);
+        }
+
+        String connectionHolder = properties.getConnectionHolder();
+        if (StringUtils.isNotBlank(connectionHolder)) {
+            consumerConfig.setConnectionHolder(connectionHolder);
+        }
+
+        String loadBalancer = properties.getLoadBalancer();
+        if (StringUtils.isNotBlank(loadBalancer)) {
+            consumerConfig.setLoadBalancer(loadBalancer);
+        }
+
+        String proxy = properties.getProxy();
+        if (StringUtils.isNotBlank(proxy)) {
+            consumerConfig.setProxy(proxy);
+        }
+    }
+
+    @Override
+    public void processorProvider(ProviderConfig providerConfig) {
+        String proxy = properties.getProxy();
+        if (StringUtils.isNotBlank(proxy)) {
+            providerConfig.setProxy(proxy);
+        }
+    }
+}

--- a/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/main/java/com/alipay/sofa/rpc/boot/ext/RpcExtensionBeanPostProcessor.java
+++ b/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/main/java/com/alipay/sofa/rpc/boot/ext/RpcExtensionBeanPostProcessor.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.rpc.boot.ext;
+
+import com.alipay.sofa.rpc.ext.Extension;
+import com.alipay.sofa.rpc.ext.ExtensionLoader;
+import com.alipay.sofa.rpc.ext.ExtensionLoaderFactory;
+import com.alipay.sofa.rpc.log.Logger;
+import com.alipay.sofa.rpc.log.LoggerFactory;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.core.annotation.AnnotationUtils;
+
+/**
+ * @author zhaowang
+ * @version : RpcExtensionBeanPostProcessor.java, v 0.1 2020年05月08日 2:27 下午 zhaowang Exp $
+ */
+public class RpcExtensionBeanPostProcessor implements BeanPostProcessor {
+
+    private static final Logger LOGGER = LoggerFactory
+                                           .getLogger(RpcExtensionBeanPostProcessor.class);
+
+    @Override
+    public Object postProcessBeforeInitialization(Object bean, String beanName)
+                                                                               throws BeansException {
+        Class<?> extensionClass = bean.getClass();
+        Extension extension = AnnotationUtils.findAnnotation(extensionClass, Extension.class);
+        if (extension != null) {
+            Class<?> extensionPoint = extension.extensionPoint();
+            if (extensionPoint == null || extensionPoint == void.class) {
+                throw new IllegalStateException(
+                    "Can not load extension which doesn't specify extensionPoint");
+            }
+            ExtensionLoader<?> extensionLoader = ExtensionLoaderFactory
+                .getExtensionLoader(extensionPoint);
+            extensionLoader.loadExtension(extensionClass);
+        }
+        return bean;
+    }
+}

--- a/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/main/java/com/alipay/sofa/rpc/boot/ext/RpcExtensionBeanPostProcessor.java
+++ b/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/main/java/com/alipay/sofa/rpc/boot/ext/RpcExtensionBeanPostProcessor.java
@@ -61,7 +61,7 @@ public class RpcExtensionBeanPostProcessor implements BeanPostProcessor {
     }
 
     private static boolean isExtensible(Class<?> clazz) {
-        Extensible annotation = AnnotationUtils.findAnnotation(clazz, Extensible.class);
+        Extensible annotation = clazz.getAnnotation(Extensible.class);
         return annotation != null;
 
     }

--- a/sofa-boot-project/sofaboot-dependencies/pom.xml
+++ b/sofa-boot-project/sofaboot-dependencies/pom.xml
@@ -30,7 +30,7 @@
 
         <!--core-->
         <tracer.core.version>3.0.8</tracer.core.version>
-        <rpc.core.version>5.7.0</rpc.core.version>
+        <rpc.core.version>5.7.1-SNAPSHOT</rpc.core.version>
 
         <!--2rd lib dependency-->
         <sofa.common.tools.version>1.0.22</sofa.common.tools.version>


### PR DESCRIPTION
For example , we can add a filter like this :
```java
@Service
@Extension(value = "custom0", extensionPoint = Filter.class)
@AutoActive(providerSide = true)
public class CustomFilter extends Filter {

    @Override
    public SofaResponse invoke(FilterInvoker invoker, SofaRequest request) throws SofaRpcException {
        //do something
       return invoker.invoke(request);
    }
}

```


**PAY ATTENTION**:  When using  this approach  **MUST**  specify extensionPoint of that extension.