### PR TITLE
Rpc-starter use sofa-common-tools's SofaConfig instead of System.getProperty

### DIFF
--- a/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/main/java/com/alipay/sofa/rpc/boot/config/SofaBootRpcConfigKeys.java
+++ b/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/main/java/com/alipay/sofa/rpc/boot/config/SofaBootRpcConfigKeys.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.rpc.boot.config;
+
+import com.alipay.sofa.common.config.ConfigKey;
+
+/**
+ * @author zhaowang
+ * @version : SofaBootRpcConfigKeys.java, v 0.1 2020年12月23日 11:21 上午 zhaowang Exp $
+ */
+public class SofaBootRpcConfigKeys {
+
+    // registry
+    public static ConfigKey<String> DEFAULT_REGISTRY = ConfigKey.build(
+                                                         "sofa.rpc.registry.defaultRegistry", "",
+                                                         false, "默认注册中心实现",
+                                                         new String[] { "default.registry" });
+
+}

--- a/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/main/java/com/alipay/sofa/rpc/boot/container/RegistryConfigContainer.java
+++ b/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/main/java/com/alipay/sofa/rpc/boot/container/RegistryConfigContainer.java
@@ -16,9 +16,11 @@
  */
 package com.alipay.sofa.rpc.boot.container;
 
+import com.alipay.sofa.common.config.SofaConfigs;
 import com.alipay.sofa.rpc.boot.common.SofaBootRpcRuntimeException;
 import com.alipay.sofa.rpc.boot.config.RegistryConfigureProcessor;
 import com.alipay.sofa.rpc.boot.config.SofaBootRpcConfigConstants;
+import com.alipay.sofa.rpc.boot.config.SofaBootRpcConfigKeys;
 import com.alipay.sofa.rpc.boot.config.SofaBootRpcProperties;
 import com.alipay.sofa.rpc.common.SofaOptions;
 import com.alipay.sofa.rpc.common.utils.StringUtils;
@@ -66,7 +68,7 @@ public class RegistryConfigContainer {
     private String                                  customDefaultRegistryAddress;
 
     public RegistryConfigContainer() {
-        customDefaultRegistry = System.getProperty(SofaBootRpcConfigConstants.DEFAULT_REGISTRY);
+        customDefaultRegistry = SofaConfigs.getOrDefault(SofaBootRpcConfigKeys.DEFAULT_REGISTRY);
         if (StringUtils.isNotBlank(customDefaultRegistry)) {
             customDefaultRegistryAddress = System.getProperty(customDefaultRegistry);
         }


### PR DESCRIPTION
Rpc-starter use sofa-common-tools's SofaConfig instead of System.getProperty