### PR TITLE
减少报错App is still in startup process, please try later!的概率

### DIFF
--- a/sofa-boot-project/sofa-boot-actuator/src/main/java/com/alipay/sofa/boot/actuator/health/SofaBootHealthIndicator.java
+++ b/sofa-boot-project/sofa-boot-actuator/src/main/java/com/alipay/sofa/boot/actuator/health/SofaBootHealthIndicator.java
@@ -45,9 +45,26 @@ public class SofaBootHealthIndicator implements HealthIndicator, NonReadinessChe
 
     @Autowired
     private ReadinessCheckListener readinessCheckListener;
+    
+    private static final Integer MAXPOLLINGNUM = 10;
+    
+    private static final Integer SLEEPTIME = 1000;
 
     @Override
     public Health health() {
+        int i = 0;
+		while (!readinessCheckListener.isReadinessCheckFinish()){
+			try {
+				Thread.sleep(SLEEPTIME);
+			} catch (InterruptedException e) {
+				e.printStackTrace();
+			}
+			if (i>MAXPOLLINGNUM){
+				break;
+			}
+			i++;
+        }
+    
         Assert.isTrue(readinessCheckListener.isReadinessCheckFinish(),
             SofaBootConstants.SOFABOOT_HEALTH_CHECK_NOT_READY_MSG);
 


### PR DESCRIPTION
减少报错App is still in startup process, please try later!的概率，由于项目还没有启动完成，健康检查检查的时候会报错App is still in startup process, please try later!。我没有想到很优雅的解决方案。