### PR TITLE
Improve HealthCheck: add progress and timeout.(#837)

### DIFF
--- a/sofa-boot-project/sofa-boot-core/healthcheck-sofa-boot/src/main/java/com/alipay/sofa/healthcheck/HealthCheckerProcessor.java
+++ b/sofa-boot-project/sofa-boot-core/healthcheck-sofa-boot/src/main/java/com/alipay/sofa/healthcheck/HealthCheckerProcessor.java
@@ -20,6 +20,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
@@ -162,6 +163,11 @@ public class HealthCheckerProcessor {
                     .submitTask(environment, healthChecker::isHealthy);
             try {
                 health = future.get(timeout, TimeUnit.MILLISECONDS);
+            }  catch (TimeoutException e) {
+                logger.error(
+                        "Timeout occurred while doing HealthChecker[{}] {} check, the timeout value is: {}ms.",
+                        beanId, checkType, timeout);
+                health = new Health.Builder().withException(e).status(Status.UNKNOWN).build();
             } catch (Throwable e) {
                 logger.error(String.format(
                         "Exception occurred while wait the result of HealthChecker[%s] %s check.",

--- a/sofa-boot-project/sofa-boot-core/healthcheck-sofa-boot/src/main/java/com/alipay/sofa/healthcheck/HealthCheckerProcessor.java
+++ b/sofa-boot-project/sofa-boot-core/healthcheck-sofa-boot/src/main/java/com/alipay/sofa/healthcheck/HealthCheckerProcessor.java
@@ -121,6 +121,7 @@ public class HealthCheckerProcessor {
 
         logger.info("Begin SOFABoot HealthChecker readiness check.");
         String checkComponentNames = healthCheckers.values().stream()
+                .filter(healthChecker -> !(healthChecker instanceof NonReadinessCheck))
                 .map(HealthChecker::getComponentName).collect(Collectors.joining(","));
         logger.info("SOFABoot HealthChecker readiness check {} item: {}.",
                 healthCheckers.size(), checkComponentNames);

--- a/sofa-boot-project/sofa-boot-core/healthcheck-sofa-boot/src/main/java/com/alipay/sofa/healthcheck/HealthCheckerProcessor.java
+++ b/sofa-boot-project/sofa-boot-core/healthcheck-sofa-boot/src/main/java/com/alipay/sofa/healthcheck/HealthCheckerProcessor.java
@@ -120,13 +120,14 @@ public class HealthCheckerProcessor {
         Assert.notNull(healthCheckers, "HealthCheckers must not be null.");
 
         logger.info("Begin SOFABoot HealthChecker readiness check.");
-        String checkComponentNames = healthCheckers.values().stream()
-                .filter(healthChecker -> !(healthChecker instanceof NonReadinessCheck))
+        Map<String, HealthChecker> readinessHealthCheckers = healthCheckers.entrySet().stream()
+                .filter(entry -> !(entry.getValue() instanceof NonReadinessCheck))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        String checkComponentNames = readinessHealthCheckers.values().stream()
                 .map(HealthChecker::getComponentName).collect(Collectors.joining(","));
         logger.info("SOFABoot HealthChecker readiness check {} item: {}.",
                 healthCheckers.size(), checkComponentNames);
-        boolean result = healthCheckers.entrySet().stream()
-                .filter(entry -> !(entry.getValue() instanceof NonReadinessCheck))
+        boolean result = readinessHealthCheckers.entrySet().stream()
                 .map(entry -> doHealthCheck(entry.getKey(), entry.getValue(), true, healthMap, true))
                 .reduce(true, BinaryOperators.andBoolean());
         if (result) {

--- a/sofa-boot-project/sofa-boot-core/healthcheck-sofa-boot/src/main/java/com/alipay/sofa/healthcheck/HealthCheckerProcessor.java
+++ b/sofa-boot-project/sofa-boot-core/healthcheck-sofa-boot/src/main/java/com/alipay/sofa/healthcheck/HealthCheckerProcessor.java
@@ -161,7 +161,7 @@ public class HealthCheckerProcessor {
         }
         do {
             Future<Health> future = HealthCheckExecutor
-                    .submitTask(environment, healthChecker::isHealthy);
+                    .submitTask(healthChecker::isHealthy);
             try {
                 health = future.get(timeout, TimeUnit.MILLISECONDS);
             }  catch (TimeoutException e) {

--- a/sofa-boot-project/sofa-boot-core/healthcheck-sofa-boot/src/main/java/com/alipay/sofa/healthcheck/HealthCheckerProcessor.java
+++ b/sofa-boot-project/sofa-boot-core/healthcheck-sofa-boot/src/main/java/com/alipay/sofa/healthcheck/HealthCheckerProcessor.java
@@ -18,14 +18,20 @@ package com.alipay.sofa.healthcheck;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
 
+import com.alipay.sofa.boot.constant.SofaBootConstants;
+import com.alipay.sofa.healthcheck.core.HealthCheckExecutor;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.Status;
 import org.springframework.context.ApplicationContext;
+import org.springframework.core.env.Environment;
 import org.springframework.util.Assert;
 
 import com.alipay.sofa.boot.health.NonReadinessCheck;
@@ -54,12 +60,18 @@ public class HealthCheckerProcessor {
 
     @Autowired
     private ApplicationContext                   applicationContext;
+    private Environment                          environment;
 
     private LinkedHashMap<String, HealthChecker> healthCheckers = null;
+
+    @Value("${" + SofaBootConstants.SOFABOOT_HEALTH_CHECK_DEFAULT_TIMEOUT + ":"
+           + SofaBootConstants.SOFABOOT_HEALTH_CHECK_DEFAULT_TIMEOUT_VALUE + "}")
+    private int                                  defaultTimeout;
 
     public void init() {
         if (isInitiated.compareAndSet(false, true)) {
             Assert.notNull(applicationContext, () -> "Application must not be null");
+            environment = applicationContext.getEnvironment();
             Map<String, HealthChecker> beansOfType = applicationContext
                     .getBeansOfType(HealthChecker.class);
             healthCheckers = HealthCheckUtils.sortMapAccordingToValue(beansOfType,
@@ -82,6 +94,10 @@ public class HealthCheckerProcessor {
         Assert.notNull(healthCheckers, () -> "HealthCheckers must not be null");
 
         logger.info("Begin SOFABoot HealthChecker liveness check.");
+        String checkComponentNames = healthCheckers.values().stream()
+                .map(HealthChecker::getComponentName).collect(Collectors.joining(","));
+        logger.info("SOFABoot HealthChecker liveness check {} item: {}.",
+                healthCheckers.size(), checkComponentNames);
         boolean result = healthCheckers.entrySet().stream()
                 .map(entry -> doHealthCheck(entry.getKey(), entry.getValue(), false, healthMap, false))
                 .reduce(true, BinaryOperators.andBoolean());
@@ -103,6 +119,10 @@ public class HealthCheckerProcessor {
         Assert.notNull(healthCheckers, "HealthCheckers must not be null.");
 
         logger.info("Begin SOFABoot HealthChecker readiness check.");
+        String checkComponentNames = healthCheckers.values().stream()
+                .map(HealthChecker::getComponentName).collect(Collectors.joining(","));
+        logger.info("SOFABoot HealthChecker readiness check {} item: {}.",
+                healthCheckers.size(), checkComponentNames);
         boolean result = healthCheckers.entrySet().stream()
                 .filter(entry -> !(entry.getValue() instanceof NonReadinessCheck))
                 .map(entry -> doHealthCheck(entry.getKey(), entry.getValue(), true, healthMap, true))
@@ -132,8 +152,22 @@ public class HealthCheckerProcessor {
         boolean result;
         int retryCount = 0;
         String checkType = isReadiness ? "readiness" : "liveness";
+        logger.info("HealthChecker[{}] {} check start.", beanId, checkType);
+        int timeout = healthChecker.getTimeout();
+        if(timeout <= 0){
+            timeout = defaultTimeout;
+        }
         do {
-            health = healthChecker.isHealthy();
+            Future<Health> future = HealthCheckExecutor
+                    .submitTask(environment, healthChecker::isHealthy);
+            try {
+                health = future.get(timeout, TimeUnit.MILLISECONDS);
+            } catch (Throwable e) {
+                logger.error(String.format(
+                        "Exception occurred while wait the result of HealthChecker[%s] %s check.",
+                        beanId, checkType), e);
+                health = new Health.Builder().withException(e).status(Status.DOWN).build();
+            }
             result = health.getStatus().equals(Status.UP);
             if (result) {
                 logger.info("HealthChecker[{}] {} check success with {} retry.", beanId, checkType,

--- a/sofa-boot-project/sofa-boot-core/healthcheck-sofa-boot/src/main/java/com/alipay/sofa/healthcheck/HealthIndicatorProcessor.java
+++ b/sofa-boot-project/sofa-boot-core/healthcheck-sofa-boot/src/main/java/com/alipay/sofa/healthcheck/HealthIndicatorProcessor.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
@@ -194,6 +195,11 @@ public class HealthIndicatorProcessor {
                         objectMapper.writeValueAsString(health.getDetails()));
             }
             healthMap.put(getKey(beanId), health);
+        } catch (TimeoutException e) {
+            result = false;
+            logger.error(
+                    "HealthIndicator[{}] readiness check fail; the status is: {}; the detail is: timeout, the timeout value is: {}ms.",
+                    beanId, Status.UNKNOWN, timeout);
         } catch (Exception e) {
             result = false;
             logger.error(

--- a/sofa-boot-project/sofa-boot-core/healthcheck-sofa-boot/src/main/java/com/alipay/sofa/healthcheck/HealthIndicatorProcessor.java
+++ b/sofa-boot-project/sofa-boot-core/healthcheck-sofa-boot/src/main/java/com/alipay/sofa/healthcheck/HealthIndicatorProcessor.java
@@ -85,8 +85,7 @@ public class HealthIndicatorProcessor {
     private Set<Class<?>>                          excludedIndicators;
 
     @Value("${" + SofaBootConstants.SOFABOOT_HEALTH_CHECK_DEFAULT_TIMEOUT + ":"
-           + SofaBootConstants.SOFABOOT_HEALTH_CHECK_DEFAULT_TIMEOUT_VALUE
-           + "}")
+           + SofaBootConstants.SOFABOOT_HEALTH_CHECK_DEFAULT_TIMEOUT_VALUE + "}")
     private int                                    defaultTimeout;
 
     public void init() {

--- a/sofa-boot-project/sofa-boot-core/healthcheck-sofa-boot/src/main/java/com/alipay/sofa/healthcheck/HealthIndicatorProcessor.java
+++ b/sofa-boot-project/sofa-boot-core/healthcheck-sofa-boot/src/main/java/com/alipay/sofa/healthcheck/HealthIndicatorProcessor.java
@@ -75,6 +75,7 @@ public class HealthIndicatorProcessor {
 
     @Autowired
     private ApplicationContext                     applicationContext;
+
     private Environment                            environment;
 
     private final static String                    REACTOR_CLASS              = "reactor.core.publisher.Mono";

--- a/sofa-boot-project/sofa-boot-core/healthcheck-sofa-boot/src/main/java/com/alipay/sofa/healthcheck/HealthIndicatorProcessor.java
+++ b/sofa-boot-project/sofa-boot-core/healthcheck-sofa-boot/src/main/java/com/alipay/sofa/healthcheck/HealthIndicatorProcessor.java
@@ -182,7 +182,7 @@ public class HealthIndicatorProcessor {
         }
         try {
             Future<Health> future = HealthCheckExecutor
-                    .submitTask(environment, healthIndicator::health);
+                    .submitTask(healthIndicator::health);
             health = future.get(timeout, TimeUnit.MILLISECONDS);
             Status status = health.getStatus();
             result = status.equals(Status.UP);

--- a/sofa-boot-project/sofa-boot-core/healthcheck-sofa-boot/src/main/java/com/alipay/sofa/healthcheck/core/HealthCheckExecutor.java
+++ b/sofa-boot-project/sofa-boot-core/healthcheck-sofa-boot/src/main/java/com/alipay/sofa/healthcheck/core/HealthCheckExecutor.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.healthcheck.core;
+
+import com.alipay.sofa.boot.constant.SofaBootConstants;
+import com.alipay.sofa.boot.util.NamedThreadFactory;
+import com.alipay.sofa.common.thread.SofaThreadPoolExecutor;
+import com.alipay.sofa.healthcheck.HealthCheckerProcessor;
+import com.alipay.sofa.healthcheck.log.HealthCheckLoggerFactory;
+import org.slf4j.Logger;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.core.env.Environment;
+
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Health Check Thread Pool
+ *
+ * @author linnan
+ * @since 3.7.1
+ */
+public class HealthCheckExecutor {
+
+    private static Logger                                    logger          = HealthCheckLoggerFactory
+                                                                                 .getLogger(HealthCheckerProcessor.class);
+    private static final int                                 CPU_COUNT       = Runtime
+                                                                                 .getRuntime()
+                                                                                 .availableProcessors();
+    private static final AtomicReference<ThreadPoolExecutor> THREAD_POOL_REF = new AtomicReference<ThreadPoolExecutor>();
+
+    public static Future<Health> submitTask(Environment environment, Callable<Health> callable) {
+        if (THREAD_POOL_REF.get() == null) {
+            ThreadPoolExecutor threadPoolExecutor = createThreadPoolExecutor(environment);
+            boolean success = THREAD_POOL_REF.compareAndSet(null, threadPoolExecutor);
+            if (!success) {
+                threadPoolExecutor.shutdown();
+            }
+        }
+        return THREAD_POOL_REF.get().submit(callable);
+    }
+
+    /**
+     * Create thread pool to execute health check.
+     * @return
+     */
+    private static ThreadPoolExecutor createThreadPoolExecutor(Environment environment) {
+        int threadPoolCoreSize = CPU_COUNT + 1;
+        String coreSizeStr = environment
+            .getProperty(SofaBootConstants.SOFABOOT_HEALTH_CHECK_THREAD_POOL_CORE_SIZE);
+        if (coreSizeStr != null) {
+            threadPoolCoreSize = Integer.parseInt(coreSizeStr);
+        }
+
+        int threadPoolMaxSize = CPU_COUNT + 1;
+        String maxSizeStr = environment
+            .getProperty(SofaBootConstants.SOFABOOT_HEALTH_CHECK_THREAD_POOL_MAX_SIZE);
+        if (maxSizeStr != null) {
+            threadPoolMaxSize = Integer.parseInt(maxSizeStr);
+        }
+
+        logger.info("create health-check thread pool, corePoolSize: {}, maxPoolSize: {}.",
+            threadPoolCoreSize, threadPoolMaxSize);
+        return new SofaThreadPoolExecutor(threadPoolCoreSize, threadPoolMaxSize, 30,
+            TimeUnit.SECONDS, new SynchronousQueue<Runnable>(), new NamedThreadFactory(
+                "health-check"), new ThreadPoolExecutor.CallerRunsPolicy(), "health-check",
+            "sofa-boot");
+    }
+}

--- a/sofa-boot-project/sofa-boot-core/healthcheck-sofa-boot/src/main/java/com/alipay/sofa/healthcheck/core/HealthCheckExecutor.java
+++ b/sofa-boot-project/sofa-boot-core/healthcheck-sofa-boot/src/main/java/com/alipay/sofa/healthcheck/core/HealthCheckExecutor.java
@@ -38,9 +38,6 @@ public class HealthCheckExecutor {
 
     private static Logger                                    logger          = HealthCheckLoggerFactory
                                                                                  .getLogger(HealthCheckerProcessor.class);
-    private static final int                                 CPU_COUNT       = Runtime
-                                                                                 .getRuntime()
-                                                                                 .availableProcessors();
     private static final AtomicReference<ThreadPoolExecutor> THREAD_POOL_REF = new AtomicReference<ThreadPoolExecutor>();
 
     public static Future<Health> submitTask(Environment environment, Callable<Health> callable) {
@@ -59,23 +56,8 @@ public class HealthCheckExecutor {
      * @return
      */
     private static ThreadPoolExecutor createThreadPoolExecutor(Environment environment) {
-        int threadPoolCoreSize = CPU_COUNT + 1;
-        String coreSizeStr = environment
-            .getProperty(SofaBootConstants.SOFABOOT_HEALTH_CHECK_THREAD_POOL_CORE_SIZE);
-        if (coreSizeStr != null) {
-            threadPoolCoreSize = Integer.parseInt(coreSizeStr);
-        }
-
-        int threadPoolMaxSize = CPU_COUNT + 1;
-        String maxSizeStr = environment
-            .getProperty(SofaBootConstants.SOFABOOT_HEALTH_CHECK_THREAD_POOL_MAX_SIZE);
-        if (maxSizeStr != null) {
-            threadPoolMaxSize = Integer.parseInt(maxSizeStr);
-        }
-
-        logger.info("create health-check thread pool, corePoolSize: {}, maxPoolSize: {}.",
-            threadPoolCoreSize, threadPoolMaxSize);
-        return new SofaThreadPoolExecutor(threadPoolCoreSize, threadPoolMaxSize, 30,
+        logger.info("create health-check thread pool, corePoolSize: 1, maxPoolSize: 1.");
+        return new SofaThreadPoolExecutor(1, 1, 30,
             TimeUnit.SECONDS, new SynchronousQueue<Runnable>(), new NamedThreadFactory(
                 "health-check"), new ThreadPoolExecutor.CallerRunsPolicy(), "health-check",
             "sofa-boot");

--- a/sofa-boot-project/sofa-boot-core/healthcheck-sofa-boot/src/main/java/com/alipay/sofa/healthcheck/core/HealthCheckExecutor.java
+++ b/sofa-boot-project/sofa-boot-core/healthcheck-sofa-boot/src/main/java/com/alipay/sofa/healthcheck/core/HealthCheckExecutor.java
@@ -32,7 +32,7 @@ import java.util.concurrent.*;
  */
 public class HealthCheckExecutor {
 
-    private static       Logger             logger          = HealthCheckLoggerFactory
+    private static Logger                   logger          = HealthCheckLoggerFactory
                                                                 .getLogger(HealthCheckExecutor.class);
     private static final ThreadPoolExecutor THREAD_POOL_REF = createThreadPoolExecutor();
 
@@ -42,12 +42,12 @@ public class HealthCheckExecutor {
 
     /**
      * Create thread pool to execute health check.
-     * @return
+     * @return thread pool to execute health check.
      */
     private static ThreadPoolExecutor createThreadPoolExecutor() {
         logger.info("create health-check thread pool, corePoolSize: 1, maxPoolSize: 1.");
         return new SofaThreadPoolExecutor(1, 1, 30, TimeUnit.SECONDS,
-                new SynchronousQueue<Runnable>(), new NamedThreadFactory("health-check"),
-                new ThreadPoolExecutor.CallerRunsPolicy(), "health-check", "sofa-boot");
+            new SynchronousQueue<Runnable>(), new NamedThreadFactory("health-check"),
+            new ThreadPoolExecutor.CallerRunsPolicy(), "health-check", "sofa-boot");
     }
 }

--- a/sofa-boot-project/sofa-boot-core/healthcheck-sofa-boot/src/main/java/com/alipay/sofa/healthcheck/core/HealthCheckExecutor.java
+++ b/sofa-boot-project/sofa-boot-core/healthcheck-sofa-boot/src/main/java/com/alipay/sofa/healthcheck/core/HealthCheckExecutor.java
@@ -16,13 +16,18 @@
  */
 package com.alipay.sofa.healthcheck.core;
 
+import com.alipay.sofa.boot.constant.SofaBootConstants;
 import com.alipay.sofa.boot.util.NamedThreadFactory;
 import com.alipay.sofa.common.thread.SofaThreadPoolExecutor;
 import com.alipay.sofa.healthcheck.log.HealthCheckLoggerFactory;
 import org.slf4j.Logger;
 import org.springframework.boot.actuate.health.Health;
 
-import java.util.concurrent.*;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Future;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Health Check Thread Pool
@@ -31,9 +36,9 @@ import java.util.concurrent.*;
  * @since 3.7.1
  */
 public class HealthCheckExecutor {
-
     private static Logger                   logger          = HealthCheckLoggerFactory
                                                                 .getLogger(HealthCheckExecutor.class);
+
     private static final ThreadPoolExecutor THREAD_POOL_REF = createThreadPoolExecutor();
 
     public static Future<Health> submitTask(Callable<Health> callable) {
@@ -45,9 +50,10 @@ public class HealthCheckExecutor {
      * @return thread pool to execute health check.
      */
     private static ThreadPoolExecutor createThreadPoolExecutor() {
-        logger.info("create health-check thread pool, corePoolSize: 1, maxPoolSize: 1.");
+        logger.info("Create health-check thread pool, corePoolSize: 1, maxPoolSize: 1.");
         return new SofaThreadPoolExecutor(1, 1, 30, TimeUnit.SECONDS,
             new SynchronousQueue<Runnable>(), new NamedThreadFactory("health-check"),
-            new ThreadPoolExecutor.CallerRunsPolicy(), "health-check", "sofa-boot");
+            new ThreadPoolExecutor.CallerRunsPolicy(), "health-check",
+            SofaBootConstants.SOFABOOT_SPACE_NAME);
     }
 }

--- a/sofa-boot-project/sofa-boot-core/healthcheck-sofa-boot/src/main/java/com/alipay/sofa/healthcheck/core/HealthCheckExecutor.java
+++ b/sofa-boot-project/sofa-boot-core/healthcheck-sofa-boot/src/main/java/com/alipay/sofa/healthcheck/core/HealthCheckExecutor.java
@@ -16,14 +16,12 @@
  */
 package com.alipay.sofa.healthcheck.core;
 
-import com.alipay.sofa.boot.constant.SofaBootConstants;
 import com.alipay.sofa.boot.util.NamedThreadFactory;
 import com.alipay.sofa.common.thread.SofaThreadPoolExecutor;
 import com.alipay.sofa.healthcheck.HealthCheckerProcessor;
 import com.alipay.sofa.healthcheck.log.HealthCheckLoggerFactory;
 import org.slf4j.Logger;
 import org.springframework.boot.actuate.health.Health;
-import org.springframework.core.env.Environment;
 
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicReference;
@@ -40,9 +38,9 @@ public class HealthCheckExecutor {
                                                                                  .getLogger(HealthCheckerProcessor.class);
     private static final AtomicReference<ThreadPoolExecutor> THREAD_POOL_REF = new AtomicReference<ThreadPoolExecutor>();
 
-    public static Future<Health> submitTask(Environment environment, Callable<Health> callable) {
+    public static Future<Health> submitTask(Callable<Health> callable) {
         if (THREAD_POOL_REF.get() == null) {
-            ThreadPoolExecutor threadPoolExecutor = createThreadPoolExecutor(environment);
+            ThreadPoolExecutor threadPoolExecutor = createThreadPoolExecutor();
             boolean success = THREAD_POOL_REF.compareAndSet(null, threadPoolExecutor);
             if (!success) {
                 threadPoolExecutor.shutdown();
@@ -55,7 +53,7 @@ public class HealthCheckExecutor {
      * Create thread pool to execute health check.
      * @return
      */
-    private static ThreadPoolExecutor createThreadPoolExecutor(Environment environment) {
+    private static ThreadPoolExecutor createThreadPoolExecutor() {
         logger.info("create health-check thread pool, corePoolSize: 1, maxPoolSize: 1.");
         return new SofaThreadPoolExecutor(1, 1, 30,
             TimeUnit.SECONDS, new SynchronousQueue<Runnable>(), new NamedThreadFactory(

--- a/sofa-boot-project/sofa-boot-core/healthcheck-sofa-boot/src/main/java/com/alipay/sofa/healthcheck/core/HealthChecker.java
+++ b/sofa-boot-project/sofa-boot-core/healthcheck-sofa-boot/src/main/java/com/alipay/sofa/healthcheck/core/HealthChecker.java
@@ -61,4 +61,13 @@ public interface HealthChecker {
     default boolean isStrictCheck() {
         return true;
     }
+
+    /**
+     * The timeout in milliseconds.
+     * If less than or equal to 0, the property {@literal com.alipay.sofa.healthcheck.component.timeout} is used as timeout.
+     * @return
+     */
+    default int getTimeout() {
+        return 0;
+    }
 }

--- a/sofa-boot-project/sofa-boot-core/healthcheck-sofa-boot/src/main/java/com/alipay/sofa/healthcheck/impl/ComponentHealthChecker.java
+++ b/sofa-boot-project/sofa-boot-core/healthcheck-sofa-boot/src/main/java/com/alipay/sofa/healthcheck/impl/ComponentHealthChecker.java
@@ -49,6 +49,10 @@ public class ComponentHealthChecker implements HealthChecker {
            + SofaBootConstants.SOFABOOT_COMPONENT_CHECK_STRICT_DEFAULT_ENABLED + "}")
     private boolean            strictCheck;
 
+    @Value("${" + SofaBootConstants.SOFABOOT_COMPONENT_HEALTH_CHECK_TIMEOUT + ":"
+           + SofaBootConstants.SOFABOOT_COMPONENT_HEALTH_CHECK_DEFAULT_TIMEOUT + "}")
+    private int                timeout;
+
     private SofaRuntimeContext sofaRuntimeContext;
 
     public ComponentHealthChecker(SofaRuntimeContext sofaRuntimeContext) {
@@ -103,6 +107,11 @@ public class ComponentHealthChecker implements HealthChecker {
     @Override
     public boolean isStrictCheck() {
         return strictCheck;
+    }
+
+    @Override
+    public int getTimeout() {
+        return timeout;
     }
 
     private static class Pair {

--- a/sofa-boot-project/sofa-boot-core/healthcheck-sofa-boot/src/main/java/com/alipay/sofa/healthcheck/impl/ModuleHealthChecker.java
+++ b/sofa-boot-project/sofa-boot-core/healthcheck-sofa-boot/src/main/java/com/alipay/sofa/healthcheck/impl/ModuleHealthChecker.java
@@ -47,6 +47,10 @@ public class ModuleHealthChecker implements ApplicationContextAware, HealthCheck
            + SofaBootConstants.SOFABOOT_MODULE_CHECK_STRICT_DEFAULT_ENABLED + "}")
     private boolean            strictCheck;
 
+    @Value("${" + SofaBootConstants.SOFABOOT_MODULE_HEALTH_CHECK_TIMEOUT + ":"
+           + SofaBootConstants.SOFABOOT_MODULE_HEALTH_CHECK_DEFAULT_TIMEOUT + "}")
+    private int                timeout;
+
     private ApplicationContext applicationContext;
 
     @Override
@@ -97,5 +101,10 @@ public class ModuleHealthChecker implements ApplicationContextAware, HealthCheck
     @Override
     public boolean isStrictCheck() {
         return strictCheck;
+    }
+
+    @Override
+    public int getTimeout() {
+        return timeout;
     }
 }

--- a/sofa-boot-project/sofa-boot-core/isle-sofa-boot/src/main/java/com/alipay/sofa/isle/stage/SpringContextInstallStage.java
+++ b/sofa-boot-project/sofa-boot-core/isle-sofa-boot/src/main/java/com/alipay/sofa/isle/stage/SpringContextInstallStage.java
@@ -186,7 +186,7 @@ public class SpringContextInstallStage extends AbstractPipelineStage {
         ThreadPoolExecutor executor = new SofaThreadPoolExecutor(CPU_COUNT + 1, CPU_COUNT + 1, 60,
             TimeUnit.MILLISECONDS, new SynchronousQueue<Runnable>(), new NamedThreadFactory(
                 "sofa-module-start"), new ThreadPoolExecutor.CallerRunsPolicy(),
-            "sofa-module-start", "sofa-boot", 60, 30, TimeUnit.SECONDS);
+            "sofa-module-start", SofaBootConstants.SOFABOOT_SPACE_NAME, 60, 30, TimeUnit.SECONDS);
         try {
             for (DeploymentDescriptor deployment : application.getResolvedDeployments()) {
                 DependencyTree.Entry entry = application.getDeployRegistry().getEntry(

--- a/sofa-boot-project/sofa-boot/src/main/java/com/alipay/sofa/boot/constant/SofaBootConstants.java
+++ b/sofa-boot-project/sofa-boot/src/main/java/com/alipay/sofa/boot/constant/SofaBootConstants.java
@@ -158,7 +158,7 @@ public class SofaBootConstants {
     /**
      * health check default timeout config value.
      */
-    public static final int     SOFABOOT_HEALTH_CHECK_DEFAULT_TIMEOUT_VALUE                  = 10 * 1000;
+    public static final int     SOFABOOT_HEALTH_CHECK_DEFAULT_TIMEOUT_VALUE                  = 60 * 1000;
 
     /**
      * {@literal com.alipay.sofa.healthcheck.impl.ComponentHealthChecker} readiness check timeout config.

--- a/sofa-boot-project/sofa-boot/src/main/java/com/alipay/sofa/boot/constant/SofaBootConstants.java
+++ b/sofa-boot-project/sofa-boot/src/main/java/com/alipay/sofa/boot/constant/SofaBootConstants.java
@@ -186,16 +186,6 @@ public class SofaBootConstants {
     public static final String  SOFABOOT_INDICATOR_HEALTH_CHECK_TIMEOUT_PREFIX               = "com.alipay.sofa.healthcheck.indicator.timeout.";
 
     /**
-     * thread pool core size to execute health check.
-     */
-    public static final String  SOFABOOT_HEALTH_CHECK_THREAD_POOL_CORE_SIZE                  = "com.alipay.sofa.healthcheck.thread.pool.core.size";
-
-    /**
-     * thread pool core size to execute health check.
-     */
-    public static final String  SOFABOOT_HEALTH_CHECK_THREAD_POOL_MAX_SIZE                   = "com.alipay.sofa.healthcheck.thread.pool.max.size";
-
-    /**
      * share parent context post processor config.
      */
     public static final String  SOFABOOT_SHARE_PARENT_CONTEXT_POST_PROCESSOR_ENABLED         = "com.alipay.sofa.boot.share.parent.context.post.processor.enabled";

--- a/sofa-boot-project/sofa-boot/src/main/java/com/alipay/sofa/boot/constant/SofaBootConstants.java
+++ b/sofa-boot-project/sofa-boot/src/main/java/com/alipay/sofa/boot/constant/SofaBootConstants.java
@@ -151,6 +151,51 @@ public class SofaBootConstants {
     public static final boolean SOFABOOT_MODULE_CHECK_STRICT_DEFAULT_ENABLED                 = true;
 
     /**
+     * health check default timeout config.
+     */
+    public static final String  SOFABOOT_HEALTH_CHECK_DEFAULT_TIMEOUT                        = "com.alipay.sofa.healthcheck.default.timeout";
+
+    /**
+     * health check default timeout config value.
+     */
+    public static final int     SOFABOOT_HEALTH_CHECK_DEFAULT_TIMEOUT_VALUE                  = 10 * 1000;
+
+    /**
+     * {@literal com.alipay.sofa.healthcheck.core.HealthChecker} readiness check timeout config.
+     */
+    public static final String  SOFABOOT_COMPONENT_HEALTH_CHECK_TIMEOUT                      = "com.alipay.sofa.healthcheck.component.timeout";
+
+    /**
+     * {@literal com.alipay.sofa.healthcheck.impl.ModuleHealthChecker} readiness check timeout config value.
+     */
+    public static final int     SOFABOOT_COMPONENT_HEALTH_CHECK_DEFAULT_TIMEOUT              = 10 * 1000;
+
+    /**
+     * {@literal com.alipay.sofa.healthcheck.impl.ModuleHealthChecker} readiness check timeout config.
+     */
+    public static final String  SOFABOOT_MODULE_HEALTH_CHECK_TIMEOUT                         = "com.alipay.sofa.healthcheck.module.timeout";
+
+    /**
+     * {@literal com.alipay.sofa.healthcheck.impl.ModuleHealthChecker} readiness check timeout config value.
+     */
+    public static final int     SOFABOOT_MODULE_HEALTH_CHECK_DEFAULT_TIMEOUT                 = 10 * 1000;
+
+    /**
+     * {@literal com.alipay.sofa.healthcheck.HealthIndicatorProcessor} readiness check timeout config prefix.
+     */
+    public static final String  SOFABOOT_INDICATOR_HEALTH_CHECK_TIMEOUT_PREFIX               = "com.alipay.sofa.healthcheck.indicator.timeout.";
+
+    /**
+     * thread pool core size to execute health check.
+     */
+    public static final String  SOFABOOT_HEALTH_CHECK_THREAD_POOL_CORE_SIZE                  = "com.alipay.sofa.healthcheck.thread.pool.core.size";
+
+    /**
+     * thread pool core size to execute health check.
+     */
+    public static final String  SOFABOOT_HEALTH_CHECK_THREAD_POOL_MAX_SIZE                   = "com.alipay.sofa.healthcheck.thread.pool.max.size";
+
+    /**
      * share parent context post processor config.
      */
     public static final String  SOFABOOT_SHARE_PARENT_CONTEXT_POST_PROCESSOR_ENABLED         = "com.alipay.sofa.boot.share.parent.context.post.processor.enabled";

--- a/sofa-boot-project/sofa-boot/src/main/java/com/alipay/sofa/boot/constant/SofaBootConstants.java
+++ b/sofa-boot-project/sofa-boot/src/main/java/com/alipay/sofa/boot/constant/SofaBootConstants.java
@@ -218,4 +218,6 @@ public class SofaBootConstants {
     public static String        MODULE_NAME                                                  = "Module-Name";
     public static String        REQUIRE_MODULE                                               = "Require-Module";
     public static String        MODULE_PROFILE                                               = "Module-Profile";
+
+    public static String        SOFABOOT_SPACE_NAME                                          = "sofa-boot";
 }

--- a/sofa-boot-project/sofa-boot/src/main/java/com/alipay/sofa/boot/constant/SofaBootConstants.java
+++ b/sofa-boot-project/sofa-boot/src/main/java/com/alipay/sofa/boot/constant/SofaBootConstants.java
@@ -161,12 +161,12 @@ public class SofaBootConstants {
     public static final int     SOFABOOT_HEALTH_CHECK_DEFAULT_TIMEOUT_VALUE                  = 10 * 1000;
 
     /**
-     * {@literal com.alipay.sofa.healthcheck.core.HealthChecker} readiness check timeout config.
+     * {@literal com.alipay.sofa.healthcheck.impl.ComponentHealthChecker} readiness check timeout config.
      */
     public static final String  SOFABOOT_COMPONENT_HEALTH_CHECK_TIMEOUT                      = "com.alipay.sofa.healthcheck.component.timeout";
 
     /**
-     * {@literal com.alipay.sofa.healthcheck.impl.ModuleHealthChecker} readiness check timeout config value.
+     * {@literal com.alipay.sofa.healthcheck.impl.ComponentHealthChecker} readiness check timeout config value.
      */
     public static final int     SOFABOOT_COMPONENT_HEALTH_CHECK_DEFAULT_TIMEOUT              = 10 * 1000;
 


### PR DESCRIPTION
# 检查进度的实现

fix #837 

## 进度日志

### HealthChecker

1. 在检查前输出了`HealthChecker`的数量和名称，其中名称是通过调用`HealthChecker.getComponentName`方法获取的
1. 在指定HealthChecker检查前，输出了check start日志

### HealthIndicator

1. 在检查前输出了`HealthIndicator`的数量和名称，其中名称使用的是beanId
1. 在指定HealthIndicator检查前，输出了check start日志

## 超时机制

超时基于线程池实现:
1. 健康检查任务提交到线程池
1. 通过`Future.get(timeout)`等待检查结果
1. 超时(TimeoutException)则认为检查失败，且健康状态为未知(`Status.UNKNOWN`)

### HealthChecker

`HealthChecker`接口增加了`getTimeout`方法，用于获取超时时间。超时时间小于等于0时，使用默认的超时时间。

### HealthIndicator

`HealthIndicator`超时时间通过配置属性获取。未配置超时时间，或配置的超时时间小于等于0时，使用默认的超时时间。
配置属性的key遵循格式: `com.alipay.sofa.healthcheck.indicator.timeout.${beanId}`。

## 新增参数

```
# 健康检查默认超时时间 默认值为 60s
com.alipay.sofa.healthcheck.default.timeout=60000
# 组件健康检查超时时间 默认值为 10s
com.alipay.sofa.healthcheck.component.timeout=10000
# sofaboot模块健康检查超时时间 默认值为 10s
com.alipay.sofa.healthcheck.module.timeout=10000
# HealthIndicator健康检查超时时间 其中beanId需替换成实际值(mongoHealthIndicator,dbHealthIndicator,redisHealthIndicator...)
com.alipay.sofa.healthcheck.indicator.timeout.${beanId}=
```