### PR TITLE
service-assignable-for-interface-type(#851)

### DIFF
--- a/sofa-boot-project/sofa-boot-autoconfigure/src/test/java/com/alipay/sofa/autoconfigure/test/runtime/SofaRuntimePropertiesTest.java
+++ b/sofa-boot-project/sofa-boot-autoconfigure/src/test/java/com/alipay/sofa/autoconfigure/test/runtime/SofaRuntimePropertiesTest.java
@@ -40,7 +40,8 @@ import com.alipay.sofa.runtime.configure.SofaRuntimeConfigurationProperties;
                                   "com.alipay.sofa.boot.skipJvmReferenceHealthCheck=true",
                                   "com.alipay.sofa.boot.skipJvmSerialize=true",
                                   "com.alipay.sofa.boot.skipExtensionHealthCheck=true",
-                                  "com.alipay.sofa.boot.extensionFailureInsulating=true" })
+                                  "com.alipay.sofa.boot.extensionFailureInsulating=true",
+                                  "com.alipay.sofa.boot.serviceAssignableInterfaceTypeCheck=true" })
 public class SofaRuntimePropertiesTest {
 
     @Autowired
@@ -90,6 +91,14 @@ public class SofaRuntimePropertiesTest {
 
         Assert.assertTrue(SofaRuntimeProperties.isSkipExtensionHealthCheck(ctx.getClassLoader()));
         Assert.assertTrue(configurationProperties.isExtensionFailureInsulating());
+    }
+
+    @Test
+    public void testServiceAssignableInterfaceTypeCheck() {
+        SofaRuntimeConfigurationProperties configurationProperties = ctx
+            .getBean(SofaRuntimeConfigurationProperties.class);
+        Assert.assertTrue(SofaRuntimeProperties.isServiceAssignableInterfaceTypeCheck());
+        Assert.assertTrue(configurationProperties.isServiceAssignableInterfaceTypeCheck());
     }
 
     @Configuration(proxyBeanMethods = false)

--- a/sofa-boot-project/sofa-boot-core/runtime-sofa-boot/src/main/java/com/alipay/sofa/runtime/SofaRuntimeProperties.java
+++ b/sofa-boot-project/sofa-boot-core/runtime-sofa-boot/src/main/java/com/alipay/sofa/runtime/SofaRuntimeProperties.java
@@ -26,14 +26,15 @@ import com.alipay.sofa.runtime.spi.component.SofaRuntimeContext;
  */
 public class SofaRuntimeProperties {
 
-    private static final ConcurrentHashMap<ClassLoader, Boolean> skipJvmReferenceHealthCheckMap = new ConcurrentHashMap<>();
-    private static final ConcurrentHashMap<ClassLoader, Boolean> skipExtensionHealthCheckMap    = new ConcurrentHashMap<>();
-    private static final ConcurrentHashMap<ClassLoader, Boolean> disableJvmFirstMap             = new ConcurrentHashMap<>();
-    private static final ConcurrentHashMap<ClassLoader, Boolean> skipJvmSerializeMap            = new ConcurrentHashMap<>();
-    private static final ConcurrentHashMap<ClassLoader, Boolean> extensionFailureInsulatingMap  = new ConcurrentHashMap<>();
+    private static final ConcurrentHashMap<ClassLoader, Boolean> skipJvmReferenceHealthCheckMap      = new ConcurrentHashMap<>();
+    private static final ConcurrentHashMap<ClassLoader, Boolean> skipExtensionHealthCheckMap         = new ConcurrentHashMap<>();
+    private static final ConcurrentHashMap<ClassLoader, Boolean> disableJvmFirstMap                  = new ConcurrentHashMap<>();
+    private static final ConcurrentHashMap<ClassLoader, Boolean> skipJvmSerializeMap                 = new ConcurrentHashMap<>();
+    private static final ConcurrentHashMap<ClassLoader, Boolean> extensionFailureInsulatingMap       = new ConcurrentHashMap<>();
 
-    private static final ConcurrentHashMap<ClassLoader, Boolean> manualReadinessCallbackMap     = new ConcurrentHashMap<>();
-    private static boolean                                       jvmFilterEnable                = false;
+    private static final ConcurrentHashMap<ClassLoader, Boolean> manualReadinessCallbackMap          = new ConcurrentHashMap<>();
+    private static boolean                                       jvmFilterEnable                     = false;
+    private static boolean                                       serviceAssignableInterfaceTypeCheck = false;
 
     public static boolean isManualReadinessCallback(ClassLoader classLoader) {
         return manualReadinessCallbackMap.get(classLoader) != null
@@ -51,6 +52,14 @@ public class SofaRuntimeProperties {
 
     public static void setJvmFilterEnable(boolean jvmFilterEnable) {
         SofaRuntimeProperties.jvmFilterEnable = jvmFilterEnable;
+    }
+
+    public static boolean isServiceAssignableInterfaceTypeCheck() {
+        return serviceAssignableInterfaceTypeCheck;
+    }
+
+    public static void setServiceAssignableInterfaceTypeCheck(boolean serviceAssignableInterfaceTypeCheck) {
+        SofaRuntimeProperties.serviceAssignableInterfaceTypeCheck = serviceAssignableInterfaceTypeCheck;
     }
 
     public static boolean isSkipJvmReferenceHealthCheck(SofaRuntimeContext sofaRuntimeContext) {

--- a/sofa-boot-project/sofa-boot-core/runtime-sofa-boot/src/main/java/com/alipay/sofa/runtime/configure/SofaRuntimeConfigurationProperties.java
+++ b/sofa-boot-project/sofa-boot-core/runtime-sofa-boot/src/main/java/com/alipay/sofa/runtime/configure/SofaRuntimeConfigurationProperties.java
@@ -98,4 +98,13 @@ public class SofaRuntimeConfigurationProperties {
             .getContextClassLoader());
     }
 
+    public void setServiceAssignableInterfaceTypeCheck(boolean serviceAssignableInterfaceTypeCheck) {
+        SofaRuntimeProperties
+            .setServiceAssignableInterfaceTypeCheck(serviceAssignableInterfaceTypeCheck);
+    }
+
+    public boolean isServiceAssignableInterfaceTypeCheck() {
+        return SofaRuntimeProperties.isServiceAssignableInterfaceTypeCheck();
+    }
+
 }

--- a/sofa-boot-project/sofa-boot-core/runtime-sofa-boot/src/main/java/com/alipay/sofa/runtime/service/component/ServiceComponent.java
+++ b/sofa-boot-project/sofa-boot-core/runtime-sofa-boot/src/main/java/com/alipay/sofa/runtime/service/component/ServiceComponent.java
@@ -23,6 +23,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
 import com.alipay.sofa.boot.error.ErrorCode;
+import com.alipay.sofa.runtime.SofaRuntimeProperties;
 import com.alipay.sofa.runtime.api.ServiceRuntimeException;
 import com.alipay.sofa.runtime.api.component.Property;
 import com.alipay.sofa.runtime.log.SofaLogger;
@@ -77,6 +78,23 @@ public class ServiceComponent extends AbstractComponent {
         return super.resolve();
     }
 
+    @Override
+    public void register() {
+        assertServiceAssignableInterfaceTypeCheck();
+        super.register();
+    }
+
+    private void assertServiceAssignableInterfaceTypeCheck() {
+        Object target = service.getTarget();
+        if (SofaRuntimeProperties.isServiceAssignableInterfaceTypeCheck()) {
+            Class<?> interfaceType = service.getInterfaceType();
+            if (!interfaceType.isAssignableFrom(target.getClass())) {
+                throw new ServiceRuntimeException(ErrorCode.convert("01-00104", service,
+                    target.getClass(), interfaceType));
+            }
+        }
+    }
+
     private void resolveBinding() {
 
         Object target = service.getTarget();
@@ -84,6 +102,7 @@ public class ServiceComponent extends AbstractComponent {
         if (target == null) {
             throw new ServiceRuntimeException(ErrorCode.convert("01-00000"));
         }
+        assertServiceAssignableInterfaceTypeCheck();
 
         if (service.hasBinding()) {
             Set<Binding> bindings = service.getBindings();
@@ -131,6 +150,7 @@ public class ServiceComponent extends AbstractComponent {
         if (target == null) {
             throw new ServiceRuntimeException(ErrorCode.convert("01-00000"));
         }
+        assertServiceAssignableInterfaceTypeCheck();
 
         if (service.hasBinding()) {
             boolean allPassed = true;
@@ -182,6 +202,7 @@ public class ServiceComponent extends AbstractComponent {
         if (target == null) {
             throw new ServiceRuntimeException(ErrorCode.convert("01-00000"));
         }
+        assertServiceAssignableInterfaceTypeCheck();
 
         if (service.hasBinding()) {
             boolean allPassed = true;
@@ -239,6 +260,7 @@ public class ServiceComponent extends AbstractComponent {
         if (target == null) {
             throw new ServiceRuntimeException(ErrorCode.convert("01-00000"));
         }
+        assertServiceAssignableInterfaceTypeCheck();
 
         if (service.hasBinding()) {
             boolean allPassed = true;

--- a/sofa-boot-project/sofa-boot-core/runtime-sofa-boot/src/test/java/com/alipay/sofa/runtime/test/SofaBindingFailTest.java
+++ b/sofa-boot-project/sofa-boot-core/runtime-sofa-boot/src/test/java/com/alipay/sofa/runtime/test/SofaBindingFailTest.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.runtime.test;
+
+import com.alipay.sofa.boot.util.StringUtils;
+import com.alipay.sofa.runtime.test.configuration.RuntimeConfiguration;
+import org.apache.commons.io.FileUtils;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.ImportResource;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/***
+ * 测试xml的service没有实现接口，发布失败
+ *
+ * @author darian1996
+ * @since 3.9
+ */
+public class SofaBindingFailTest {
+
+    @AfterClass
+    public static void afterClearLogFiles() throws IOException {
+        final String logRootPath = StringUtils.hasText(System.getProperty("logging.path")) ? System
+            .getProperty("logging.path") : "./logs";
+        FileUtils.deleteDirectory(new File(logRootPath));
+    }
+
+    @Test
+    public void testServiceBinding() throws IOException {
+        String logRootPath = StringUtils.hasText(System.getProperty("logging.path")) ? System
+            .getProperty("logging.path") : "./logs";
+        File sofaLog = new File(logRootPath + File.separator + "sofa-runtime" + File.separator
+                                + "sofa-default.log");
+        FileUtils.write(sofaLog, "", System.getProperty("file.encoding"));
+
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("spring.application.name", "SofaServiceAndReferenceTest");
+        properties.put("logging.path", logRootPath);
+        properties.put("com.alipay.sofa.boot.serviceAssignableInterfaceTypeCheck", "true");
+
+        SpringApplication springApplication = new SpringApplication(
+            SofaBindingTestNotAssignableFromInterfaceTypeConfiguration.class);
+        springApplication.setWebApplicationType(WebApplicationType.NONE);
+        springApplication.setDefaultProperties(properties);
+        springApplication.run();
+
+        String content = FileUtils.readFileToString(sofaLog, System.getProperty("file.encoding"));
+        Assert
+            .assertTrue(content
+                .contains("SOFA-BOOT-01-00104: Bean "
+                          + "[com.alipay.sofa.runtime.test.beans.facade.SampleService] "
+                          + "type is [class java.lang.Object] not isAssignableFrom "
+                          + "[interface com.alipay.sofa.runtime.test.beans.facade.SampleService] , please check it"));
+
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    @Import(RuntimeConfiguration.class)
+    @EnableAutoConfiguration
+    @ImportResource("classpath*:META-INF/service/test-service-not-assignable-from-interface-type.xml")
+    static class SofaBindingTestNotAssignableFromInterfaceTypeConfiguration {
+    }
+}

--- a/sofa-boot-project/sofa-boot-core/runtime-sofa-boot/src/test/java/com/alipay/sofa/runtime/test/SofaEventHandlerTest.java
+++ b/sofa-boot-project/sofa-boot-core/runtime-sofa-boot/src/test/java/com/alipay/sofa/runtime/test/SofaEventHandlerTest.java
@@ -75,6 +75,7 @@ public class SofaEventHandlerTest {
         properties.setProperty("com.alipay.sofa.boot.skipExtensionHealthCheck", "true");
         properties.setProperty("com.alipay.sofa.boot.skipJvmSerialize", "true");
         properties.setProperty("com.alipay.sofa.boot.extensionFailureInsulating", "true");
+        properties.setProperty("com.alipay.sofa.boot.serviceAssignableInterfaceTypeCheck", "true");
         properties.setProperty("spring.application.name", "tSofaEventHandlerTest");
         SofaFramework.getRuntimeSet().forEach(value -> SofaFramework.unRegisterSofaRuntimeManager(value));
         SpringApplication springApplication = new SpringApplication(
@@ -104,6 +105,7 @@ public class SofaEventHandlerTest {
         Assert.assertFalse(SofaRuntimeProperties.isSkipExtensionHealthCheck(ctx.getClassLoader()));
         Assert
             .assertFalse(SofaRuntimeProperties.isExtensionFailureInsulating(ctx.getClassLoader()));
+        Assert.assertFalse(SofaRuntimeProperties.isServiceAssignableInterfaceTypeCheck());
         Assert.assertFalse(SofaRuntimeProperties.isSkipJvmSerialize(ctx.getClassLoader()));
         Assert.assertTrue(SofaFramework.getRuntimeSet().isEmpty());
         Assert.assertFalse(ctx.isActive());

--- a/sofa-boot-project/sofa-boot-core/runtime-sofa-boot/src/test/java/com/alipay/sofa/runtime/test/SofaServiceAndReferenceFailTest.java
+++ b/sofa-boot-project/sofa-boot-core/runtime-sofa-boot/src/test/java/com/alipay/sofa/runtime/test/SofaServiceAndReferenceFailTest.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.runtime.test;
+
+import com.alipay.sofa.boot.util.StringUtils;
+import com.alipay.sofa.runtime.api.annotation.SofaService;
+import com.alipay.sofa.runtime.test.beans.facade.SampleService;
+import com.alipay.sofa.runtime.test.configuration.RuntimeConfiguration;
+import org.apache.commons.io.FileUtils;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * 测试发布失败
+ *
+ * @author darian1996
+ * @since 3.9.0
+ */
+public class SofaServiceAndReferenceFailTest {
+
+    @AfterClass
+    public static void clearLogFiles() throws IOException {
+        final String logRootPath = StringUtils.hasText(System.getProperty("logging.path")) ? System
+            .getProperty("logging.path") : "./logs";
+        FileUtils.deleteDirectory(new File(logRootPath));
+    }
+
+    @Test
+    public void testSofaServiceClassNotAssignableFromInterfaceType() throws IOException {
+        String logRootPath = StringUtils.hasText(System.getProperty("logging.path")) ? System
+            .getProperty("logging.path") : "./logs";
+        File sofaLog = new File(logRootPath + File.separator + "sofa-runtime" + File.separator
+                                + "sofa-default.log");
+        FileUtils.write(sofaLog, "", System.getProperty("file.encoding"));
+
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("spring.application.name",
+            "TestSofaServiceNotAssignableFromInterfaceTypeConfiguration");
+        properties.put("logging.path", logRootPath);
+        properties.put("com.alipay.sofa.boot.serviceAssignableInterfaceTypeCheck", "true");
+
+        SpringApplication springApplication = new SpringApplication(
+            TestSofaServiceNotAssignableFromInterfaceTypeConfiguration.class);
+        springApplication.setWebApplicationType(WebApplicationType.NONE);
+        springApplication.setDefaultProperties(properties);
+        springApplication.run();
+
+        String content = FileUtils.readFileToString(sofaLog, System.getProperty("file.encoding"));
+        Assert
+            .assertTrue(content
+                .contains("SOFA-BOOT-01-00104: Bean "
+                          + "[com.alipay.sofa.runtime.test.beans.facade.SampleService] "
+                          + "type is [class java.lang.Object] not isAssignableFrom "
+                          + "[interface com.alipay.sofa.runtime.test.beans.facade.SampleService] , please check it"));
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    @Import(RuntimeConfiguration.class)
+    @EnableAutoConfiguration
+    static class TestSofaServiceNotAssignableFromInterfaceTypeConfiguration {
+        @Bean
+        @SofaService(interfaceType = SampleService.class)
+        public Object object() {
+            return new Object();
+        }
+    }
+}

--- a/sofa-boot-project/sofa-boot-core/runtime-sofa-boot/src/test/java/com/alipay/sofa/runtime/test/configuration/RuntimeConfiguration.java
+++ b/sofa-boot-project/sofa-boot-core/runtime-sofa-boot/src/test/java/com/alipay/sofa/runtime/test/configuration/RuntimeConfiguration.java
@@ -22,6 +22,7 @@ import com.alipay.sofa.runtime.api.client.ReferenceClient;
 import com.alipay.sofa.runtime.api.client.ServiceClient;
 import com.alipay.sofa.runtime.client.impl.ClientFactoryImpl;
 import com.alipay.sofa.runtime.component.impl.StandardSofaRuntimeManager;
+import com.alipay.sofa.runtime.configure.SofaRuntimeConfigurationProperties;
 import com.alipay.sofa.runtime.service.client.ReferenceClientImpl;
 import com.alipay.sofa.runtime.service.client.ServiceClientImpl;
 import com.alipay.sofa.runtime.service.impl.BindingAdapterFactoryImpl;
@@ -50,6 +51,13 @@ import java.util.Set;
  */
 @Configuration(proxyBeanMethods = false)
 public class RuntimeConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean
+    public SofaRuntimeConfigurationProperties sofaRuntimeConfigurationProperties() {
+        return new SofaRuntimeConfigurationProperties();
+    }
+
     @Bean
     public static BindingConverterFactory bindingConverterFactory() {
         BindingConverterFactory bindingConverterFactory = new BindingConverterFactoryImpl();

--- a/sofa-boot-project/sofa-boot-core/runtime-sofa-boot/src/test/resources/META-INF/service/test-service-not-assignable-from-interface-type.xml
+++ b/sofa-boot-project/sofa-boot-core/runtime-sofa-boot/src/test/resources/META-INF/service/test-service-not-assignable-from-interface-type.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:sofa="http://sofastack.io/schema/sofaboot"
+       xmlns:aop="http://www.springframework.org/schema/aop"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+            http://sofastack.io/schema/sofaboot   http://sofastack.io/schema/sofaboot.xsd
+            http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd"
+       default-autowire="byName">
+
+    <bean id="objectService" class="java.lang.Object"/>
+    <sofa:service ref="objectService" interface="com.alipay.sofa.runtime.test.beans.facade.SampleService"/>
+</beans>

--- a/sofa-boot-project/sofa-boot/src/main/resources/sofa-boot/log-codes.properties
+++ b/sofa-boot-project/sofa-boot/src/main/resources/sofa-boot/log-codes.properties
@@ -17,6 +17,7 @@
 01-00101=Failed to get the implementation when not init yet
 01-00102=Unable to get implementation of reference component, there's some error occurred when register this reference component
 01-00103=Bean [%s] of type [%s] has already annotated by @SofaService can not be registered using xml. Please check it
+01-00104=Bean [%s] type is [%s] not isAssignableFrom [%s] , please check it
 01-00200=Can not found binding converter for binding type %s
 01-00201=Interface type is null. Interface type is required while publish a service
 01-00202=Argument delay must be a positive integer or zero


### PR DESCRIPTION
# ServiceClientImpl.service增加InterfaceType和Instance校验

## 配置项

```properties
# 是否开启检查服务是否是接口的实现类，默认不开启
com.alipay.sofa.boot.serviceAssignableInterfaceTypeCheck=true
```

## 实现

1. 配置项增加在 `SofaRuntimeProperties`
2. 配置项注入 `SofaRuntimeConfigurationProperties`, 可以通过：`com.alipay.sofa.boot.serviceAssignableInterfaceTypeCheck=true` 开启检查
3. 错误码定义 `log-codes.properties`
```properties
    01-00104=Bean [%s] type is [%s] not isAssignableFrom [%s] , please check it
```
4. `ServiceComponent` 根据配置进行检查

```java
private void assertServiceAssignableInterfaceTypeCheck() {
        Object target = service.getTarget();
        if (SofaRuntimeProperties.isServiceAssignableInterfaceTypeCheck()) {
            Class<?> interfaceType = service.getInterfaceType();
            if (!interfaceType.isAssignableFrom(target.getClass())) {
                throw new ServiceRuntimeException(ErrorCode.convert("01-00104", service,
                    target.getClass(), interfaceType));
            }
        }
    }
```
