### PR TITLE
adjust priority for AfterBizStartupEventHandler

### DIFF
--- a/sofa-boot-project/sofa-boot-core/runtime-sofa-boot/src/main/java/com/alipay/sofa/runtime/spring/AfterBizStartupEventHandler.java
+++ b/sofa-boot-project/sofa-boot-core/runtime-sofa-boot/src/main/java/com/alipay/sofa/runtime/spring/AfterBizStartupEventHandler.java
@@ -35,6 +35,6 @@ public class AfterBizStartupEventHandler implements EventHandler<AfterBizStartup
 
     @Override
     public int getPriority() {
-        return PriorityOrdered.DEFAULT_PRECEDENCE;
+        return PriorityOrdered.LOWEST_PRECEDENCE;
     }
 }


### PR DESCRIPTION
AfterBizStartupEventHandler 和 SofaBizHealthCheckEventHandler 优先级一样，biz 启动失败时，会导致报错 com.alipay.sofa.runtime.invoke.DynamicJvmServiceProxyFinder#afterBizStartup NullPointException