### PR TITLE
fix(sec): upgrade com.alipay.sofa:hessian to 4.0.3

### DIFF
--- a/sofa-boot-project/sofaboot-dependencies/pom.xml
+++ b/sofa-boot-project/sofaboot-dependencies/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -31,7 +29,7 @@
         <!--2rd lib dependency-->
         <sofa.common.tools.version>1.3.6</sofa.common.tools.version>
         <sofa.bolt.version>1.5.10</sofa.bolt.version>
-        <sofa.hessian.version>3.3.12</sofa.hessian.version>
+        <sofa.hessian.version>4.0.3</sofa.hessian.version>
 
         <!--3rd lib dependency-->
         <!--FIXME 1.7.36 will cause compatibility problem, see #https://www.slf4j.org/manual.html-->


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in com.alipay.sofa:hessian 3.3.12
- [CVE-2019-9212](https://www.oscs1024.com/hd/CVE-2019-9212)


### What did I do？
Upgrade com.alipay.sofa:hessian from 3.3.12 to 4.0.3 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS