### PR TITLE
fix(sec): upgrade ch.qos.logback:logback-core to 1.2.7

### DIFF
--- a/sofa-boot-project/sofa-boot-core/log-sofa-boot/pom.xml
+++ b/sofa-boot-project/sofa-boot-core/log-sofa-boot/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>sofa-boot-core</artifactId>
         <groupId>com.alipay.sofa</groupId>
@@ -13,7 +11,7 @@
 
     <properties>
         <main.user.dir>${basedir}/../../..</main.user.dir>
-        <logback.version>1.1.7</logback.version>
+        <logback.version>1.2.7</logback.version>
         <log4j2.version>2.8</log4j2.version>
     </properties>
 

--- a/sofa-boot-project/sofa-boot-starters/log-sofa-boot-starter/pom.xml
+++ b/sofa-boot-project/sofa-boot-starters/log-sofa-boot-starter/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>sofa-boot-starters</artifactId>
         <groupId>com.alipay.sofa</groupId>


### PR DESCRIPTION
### What happened？
There are 2 security vulnerabilities found in ch.qos.logback:logback-core 1.1.7
- [MPS-2022-12411](https://www.oscs1024.com/hd/MPS-2022-12411)
- [CVE-2017-5929](https://www.oscs1024.com/hd/CVE-2017-5929)


### What did I do？
Upgrade ch.qos.logback:logback-core from 1.1.7 to 1.2.7 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS