### PR TITLE
fix(sec): upgrade org.apache.logging.log4j:log4j-core to 2.17.1

### DIFF
--- a/sofa-boot-project/sofa-boot-core/log-sofa-boot/pom.xml
+++ b/sofa-boot-project/sofa-boot-core/log-sofa-boot/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>sofa-boot-core</artifactId>
         <groupId>com.alipay.sofa</groupId>
@@ -14,7 +12,7 @@
     <properties>
         <main.user.dir>${basedir}/../../..</main.user.dir>
         <logback.version>1.1.7</logback.version>
-        <log4j2.version>2.8</log4j2.version>
+        <log4j2.version>2.17.1</log4j2.version>
     </properties>
 
     <dependencies>

--- a/sofa-boot-project/sofa-boot-starters/log-sofa-boot-starter/pom.xml
+++ b/sofa-boot-project/sofa-boot-starters/log-sofa-boot-starter/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>sofa-boot-starters</artifactId>
         <groupId>com.alipay.sofa</groupId>


### PR DESCRIPTION
### What happened？
There are 6 security vulnerabilities found in org.apache.logging.log4j:log4j-core 2.8
- [CVE-2020-9488](https://www.oscs1024.com/hd/CVE-2020-9488)
- [CVE-2021-44832](https://www.oscs1024.com/hd/CVE-2021-44832)
- [CVE-2021-45105](https://www.oscs1024.com/hd/CVE-2021-45105)
- [CVE-2017-5645](https://www.oscs1024.com/hd/CVE-2017-5645)
- [CVE-2021-44228](https://www.oscs1024.com/hd/CVE-2021-44228)
- [CVE-2021-45046](https://www.oscs1024.com/hd/CVE-2021-45046)


### What did I do？
Upgrade org.apache.logging.log4j:log4j-core from 2.8 to 2.17.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS