### PR TITLE
fix(sec): upgrade org.apache.commons:commons-compress to 1.21

### DIFF
--- a/sofa-boot-project/sofa-boot-tools/sofa-boot-gradle-plugin/pom.xml
+++ b/sofa-boot-project/sofa-boot-tools/sofa-boot-gradle-plugin/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.19</version>
+            <version>1.21</version>
         </dependency>
     </dependencies>
     <build>


### PR DESCRIPTION
### What happened？
There are 3 security vulnerabilities found in org.apache.commons:commons-compress 1.19
- [CVE-2021-35517](https://www.oscs1024.com/hd/CVE-2021-35517)
- [CVE-2021-35516](https://www.oscs1024.com/hd/CVE-2021-35516)
- [CVE-2021-35515](https://www.oscs1024.com/hd/CVE-2021-35515)


### What did I do？
Upgrade org.apache.commons:commons-compress from 1.19 to 1.21 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS