### PR TITLE
Support singleton PostProcessor

### DIFF
--- a/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/runtime/SofaRuntimeAutoConfiguration.java
+++ b/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/runtime/SofaRuntimeAutoConfiguration.java
@@ -16,13 +16,13 @@
  */
 package com.alipay.sofa.boot.autoconfigure.runtime;
 
-import com.alipay.sofa.runtime.proxy.ProxyBeanFactoryPostProcessor;
 import com.alipay.sofa.runtime.SofaFramework;
 import com.alipay.sofa.runtime.api.client.ReferenceClient;
 import com.alipay.sofa.runtime.api.client.ServiceClient;
 import com.alipay.sofa.runtime.client.impl.ClientFactoryImpl;
 import com.alipay.sofa.runtime.component.impl.StandardSofaRuntimeManager;
 import com.alipay.sofa.runtime.configure.SofaRuntimeConfigurationProperties;
+import com.alipay.sofa.runtime.proxy.ProxyBeanFactoryPostProcessor;
 import com.alipay.sofa.runtime.service.client.ReferenceClientImpl;
 import com.alipay.sofa.runtime.service.client.ServiceClientImpl;
 import com.alipay.sofa.runtime.service.impl.BindingAdapterFactoryImpl;
@@ -46,10 +46,8 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.support.AbstractApplicationContext;
 import org.springframework.core.env.Environment;
 
 import java.util.HashSet;
@@ -128,11 +126,8 @@ public class SofaRuntimeAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    public static RuntimeContextBeanFactoryPostProcessor runtimeContextBeanFactoryPostProcessor(BindingAdapterFactory bindingAdapterFactory,
-                                                                                                BindingConverterFactory bindingConverterFactory,
-                                                                                                SofaRuntimeContext sofaRuntimeContext) {
-        return new RuntimeContextBeanFactoryPostProcessor(bindingAdapterFactory,
-            bindingConverterFactory, sofaRuntimeContext);
+    public static RuntimeContextBeanFactoryPostProcessor runtimeContextBeanFactoryPostProcessor() {
+        return new RuntimeContextBeanFactoryPostProcessor();
     }
 
     @Bean
@@ -145,23 +140,22 @@ public class SofaRuntimeAutoConfiguration {
     @ConditionalOnMissingBean
     @ConditionalOnClass(name = "com.alipay.sofa.isle.ApplicationRuntimeModel")
     @ConditionalOnProperty(value = "com.alipay.sofa.boot.enable-isle", matchIfMissing = true)
-    public static SofaShareBeanFactoryPostProcessor sofaModuleBeanFactoryPostProcessor(SofaPostProcessorShareManager shareManager) {
-        return new SofaShareBeanFactoryPostProcessor(shareManager);
+    public static SofaShareBeanFactoryPostProcessor sofaModuleBeanFactoryPostProcessor() {
+        return new SofaShareBeanFactoryPostProcessor();
     }
 
     @Bean
     @ConditionalOnMissingBean
     @ConditionalOnClass(name = "com.alipay.sofa.isle.ApplicationRuntimeModel")
     @ConditionalOnProperty(value = "com.alipay.sofa.boot.enable-isle", matchIfMissing = true)
-    public SofaPostProcessorShareManager sofaModulePostProcessorShareManager(ApplicationContext applicationContext) {
-        return new SofaPostProcessorShareManager((AbstractApplicationContext) applicationContext);
+    public SofaPostProcessorShareManager sofaModulePostProcessorShareManager() {
+        return new SofaPostProcessorShareManager();
     }
 
     @Bean
     @ConditionalOnMissingBean
-    public static ServiceBeanFactoryPostProcessor serviceBeanFactoryPostProcessor(SofaRuntimeContext sofaRuntimeContext,
-                                                                                  BindingConverterFactory bindingConverterFactory) {
-        return new ServiceBeanFactoryPostProcessor(sofaRuntimeContext, bindingConverterFactory);
+    public static ServiceBeanFactoryPostProcessor serviceBeanFactoryPostProcessor() {
+        return new ServiceBeanFactoryPostProcessor();
     }
 
     @Bean

--- a/sofa-boot-project/sofa-boot-core/isle-sofa-boot/src/test/java/com/alipay/sofa/isle/test/FailModuleTest.java
+++ b/sofa-boot-project/sofa-boot-core/isle-sofa-boot/src/test/java/com/alipay/sofa/isle/test/FailModuleTest.java
@@ -86,8 +86,8 @@ public class FailModuleTest {
     @EnableConfigurationProperties(SofaModuleProperties.class)
     public static class FailModuleTestConfiguration {
         @Bean
-        public static SofaShareBeanFactoryPostProcessor sofaModuleBeanFactoryPostProcessor(SofaPostProcessorShareManager shareManager) {
-            return new SofaShareBeanFactoryPostProcessor(shareManager);
+        public static SofaShareBeanFactoryPostProcessor sofaModuleBeanFactoryPostProcessor() {
+            return new SofaShareBeanFactoryPostProcessor();
         }
 
         @Bean
@@ -133,9 +133,8 @@ public class FailModuleTest {
 
         @Bean
         @ConditionalOnMissingBean
-        public SofaPostProcessorShareManager sofaModulePostProcessorShareManager(ApplicationContext applicationContext) {
-            return new SofaPostProcessorShareManager(
-                (AbstractApplicationContext) applicationContext);
+        public SofaPostProcessorShareManager sofaModulePostProcessorShareManager() {
+            return new SofaPostProcessorShareManager();
         }
 
         @Bean(destroyMethod = "")

--- a/sofa-boot-project/sofa-boot-core/isle-sofa-boot/src/test/java/com/alipay/sofa/isle/test/PostProcessorShareTest.java
+++ b/sofa-boot-project/sofa-boot-core/isle-sofa-boot/src/test/java/com/alipay/sofa/isle/test/PostProcessorShareTest.java
@@ -36,9 +36,9 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.support.AbstractApplicationContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
+
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -72,15 +72,14 @@ public class PostProcessorShareTest {
 
         @Bean
         @ConditionalOnMissingBean
-        public SofaPostProcessorShareManager sofaModulePostProcessorShareManager(ApplicationContext applicationContext) {
-            return new SofaPostProcessorShareManager(
-                (AbstractApplicationContext) applicationContext);
+        public SofaPostProcessorShareManager sofaModulePostProcessorShareManager() {
+            return new SofaPostProcessorShareManager();
         }
 
         @Bean
         @ConditionalOnMissingBean
-        public static SofaShareBeanFactoryPostProcessor sofaModuleBeanFactoryPostProcessor(SofaPostProcessorShareManager shareManager) {
-            return new SofaShareBeanFactoryPostProcessor(shareManager);
+        public static SofaShareBeanFactoryPostProcessor sofaModuleBeanFactoryPostProcessor() {
+            return new SofaShareBeanFactoryPostProcessor();
         }
 
         @Bean

--- a/sofa-boot-project/sofa-boot-core/isle-sofa-boot/src/test/java/com/alipay/sofa/isle/test/SingletonProcessorTest.java
+++ b/sofa-boot-project/sofa-boot-core/isle-sofa-boot/src/test/java/com/alipay/sofa/isle/test/SingletonProcessorTest.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.isle.test;
+
+import com.alipay.sofa.isle.profile.DefaultSofaModuleProfileChecker;
+import com.alipay.sofa.isle.profile.SofaModuleProfileChecker;
+import com.alipay.sofa.isle.spring.SofaModuleContextLifecycle;
+import com.alipay.sofa.isle.spring.config.SofaModuleProperties;
+import com.alipay.sofa.isle.stage.DefaultPipelineContext;
+import com.alipay.sofa.isle.stage.ModelCreatingStage;
+import com.alipay.sofa.isle.stage.ModuleLogOutputStage;
+import com.alipay.sofa.isle.stage.PipelineContext;
+import com.alipay.sofa.isle.stage.PipelineStage;
+import com.alipay.sofa.isle.stage.SpringContextInstallStage;
+import com.alipay.sofa.isle.test.processor.SampleBeanPostProcessor;
+import com.alipay.sofa.isle.test.processor.SingletonBeanPostProcessor;
+import com.alipay.sofa.isle.test.util.AddCustomJar;
+import com.alipay.sofa.isle.test.util.SeparateClassLoaderTestRunner;
+import com.alipay.sofa.runtime.SofaFramework;
+import com.alipay.sofa.runtime.client.impl.ClientFactoryImpl;
+import com.alipay.sofa.runtime.component.impl.StandardSofaRuntimeManager;
+import com.alipay.sofa.runtime.spi.client.ClientFactoryInternal;
+import com.alipay.sofa.runtime.spi.component.ComponentInfo;
+import com.alipay.sofa.runtime.spi.component.SofaRuntimeManager;
+import com.alipay.sofa.runtime.spring.SofaShareBeanFactoryPostProcessor;
+import com.alipay.sofa.runtime.spring.SpringContextComponent;
+import com.alipay.sofa.runtime.spring.share.SofaPostProcessorShareManager;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.support.AbstractApplicationContext;
+
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * @author huzijie
+ * @version SingletonProcessorTest.java, v 0.1 2022年10月25日 11:33 AM huzijie Exp $
+ */
+@RunWith(SeparateClassLoaderTestRunner.class)
+@SpringBootTest
+@AddCustomJar({ "dev-module-0.1.0.jar" })
+public class SingletonProcessorTest {
+
+    @Autowired
+    private SingletonBeanPostProcessor singletonBeanPostProcessor;
+
+    @Autowired
+    private SampleBeanPostProcessor    sampleBeanPostProcessor;
+
+    @Autowired
+    private SofaRuntimeManager         sofaRuntimeManager;
+
+    @Test
+    public void testSingletonBpp() {
+        Collection<ComponentInfo> components =
+                sofaRuntimeManager.getComponentManager().getComponentInfosByType(SpringContextComponent.SPRING_COMPONENT_TYPE);
+        ApplicationContext applicationContext = components.stream().filter(componentInfo -> componentInfo.getName().getRawName().contains("dev")).findFirst().get().getApplicationContext();
+        SingletonBeanPostProcessor singletonBeanPostProcessor = applicationContext.getBean(SingletonBeanPostProcessor.class);
+        SampleBeanPostProcessor sampleBeanPostProcessor = applicationContext.getBean(SampleBeanPostProcessor.class);
+        Assert.assertEquals(singletonBeanPostProcessor, this.singletonBeanPostProcessor);
+        Assert.assertNotEquals(sampleBeanPostProcessor, this.sampleBeanPostProcessor);
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    @EnableConfigurationProperties(SofaModuleProperties.class)
+    public static class SofaModuleProfileCheckerTestConfiguration {
+
+        @Bean
+        public static SofaShareBeanFactoryPostProcessor sofaModuleBeanFactoryPostProcessor() {
+            return new SofaShareBeanFactoryPostProcessor();
+        }
+
+        @Bean
+        @ConditionalOnMissingBean
+        public SofaModuleContextLifecycle sofaModuleContextLifecycle(PipelineContext pipelineContext) {
+            return new SofaModuleContextLifecycle(pipelineContext);
+        }
+
+        @Bean
+        @ConditionalOnMissingBean
+        public ModelCreatingStage modelCreatingStage(ApplicationContext applicationContext,
+                                                     SofaModuleProperties sofaModuleProperties,
+                                                     SofaModuleProfileChecker sofaModuleProfileChecker) {
+            return new ModelCreatingStage((AbstractApplicationContext) applicationContext,
+                sofaModuleProperties, sofaModuleProfileChecker);
+        }
+
+        @Bean
+        @ConditionalOnMissingBean
+        public SpringContextInstallStage springContextInstallStage(ApplicationContext applicationContext,
+                                                                   SofaModuleProperties sofaModuleProperties) {
+            return new SpringContextInstallStage((AbstractApplicationContext) applicationContext,
+                sofaModuleProperties);
+        }
+
+        @Bean
+        @ConditionalOnMissingBean
+        public ModuleLogOutputStage moduleLogOutputStage(ApplicationContext applicationContext) {
+            return new ModuleLogOutputStage((AbstractApplicationContext) applicationContext);
+        }
+
+        @Bean
+        @ConditionalOnMissingBean
+        public PipelineContext pipelineContext(List<PipelineStage> stageList) {
+            return new DefaultPipelineContext(stageList);
+        }
+
+        @Bean
+        @ConditionalOnMissingBean
+        public SofaModuleProfileChecker sofaModuleProfileChecker(SofaModuleProperties sofaModuleProperties) {
+            return new DefaultSofaModuleProfileChecker(sofaModuleProperties);
+        }
+
+        @Bean
+        @ConditionalOnMissingBean
+        public SofaPostProcessorShareManager sofaModulePostProcessorShareManager() {
+            return new SofaPostProcessorShareManager();
+        }
+
+        @Bean(destroyMethod = "")
+        @ConditionalOnMissingBean
+        public static SofaRuntimeManager sofaRuntimeManager() {
+            ClientFactoryInternal clientFactoryInternal = new ClientFactoryImpl();
+            SofaRuntimeManager sofaRuntimeManager = new StandardSofaRuntimeManager(
+                "FailModuleTest", Thread.currentThread().getContextClassLoader(),
+                clientFactoryInternal);
+            SofaFramework.registerSofaRuntimeManager(sofaRuntimeManager);
+            return sofaRuntimeManager;
+        }
+
+        @Bean
+        public SingletonBeanPostProcessor singletonBeanPostProcessor() {
+            return new SingletonBeanPostProcessor();
+        }
+
+        @Bean
+        public SampleBeanPostProcessor sampleBeanPostProcessor() {
+            return new SampleBeanPostProcessor();
+        }
+    }
+}

--- a/sofa-boot-project/sofa-boot-core/isle-sofa-boot/src/test/java/com/alipay/sofa/isle/test/processor/SingletonBeanPostProcessor.java
+++ b/sofa-boot-project/sofa-boot-core/isle-sofa-boot/src/test/java/com/alipay/sofa/isle/test/processor/SingletonBeanPostProcessor.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.isle.test.processor;
+
+import com.alipay.sofa.runtime.spring.singleton.SingletonSofaPostProcessor;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+
+/**
+ * @author huzijie
+ * @version SingletonBeanPostProcessor.java, v 0.1 2022年10月25日 11:33 AM huzijie Exp $
+ */
+@SingletonSofaPostProcessor
+public class SingletonBeanPostProcessor implements BeanPostProcessor {
+}

--- a/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/test/java/com/alipay/sofa/rpc/boot/test/RuntimeTestConfiguration.java
+++ b/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/test/java/com/alipay/sofa/rpc/boot/test/RuntimeTestConfiguration.java
@@ -94,17 +94,13 @@ public class RuntimeTestConfiguration {
     }
 
     @Bean
-    public static RuntimeContextBeanFactoryPostProcessor runtimeContextBeanFactoryPostProcessor(BindingAdapterFactory bindingAdapterFactory,
-                                                                                                BindingConverterFactory bindingConverterFactory,
-                                                                                                SofaRuntimeContext sofaRuntimeContext) {
-        return new RuntimeContextBeanFactoryPostProcessor(bindingAdapterFactory,
-            bindingConverterFactory, sofaRuntimeContext);
+    public static RuntimeContextBeanFactoryPostProcessor runtimeContextBeanFactoryPostProcessor() {
+        return new RuntimeContextBeanFactoryPostProcessor();
     }
 
     @Bean
-    public static ServiceBeanFactoryPostProcessor serviceBeanFactoryPostProcessor(SofaRuntimeContext sofaRuntimeContext,
-                                                                                  BindingConverterFactory bindingConverterFactory) {
-        return new ServiceBeanFactoryPostProcessor(sofaRuntimeContext, bindingConverterFactory);
+    public static ServiceBeanFactoryPostProcessor serviceBeanFactoryPostProcessor() {
+        return new ServiceBeanFactoryPostProcessor();
     }
 
     @Bean

--- a/sofa-boot-project/sofa-boot-core/runtime-sofa-boot/src/main/java/com/alipay/sofa/runtime/proxy/ProxyBeanFactoryPostProcessor.java
+++ b/sofa-boot-project/sofa-boot-core/runtime-sofa-boot/src/main/java/com/alipay/sofa/runtime/proxy/ProxyBeanFactoryPostProcessor.java
@@ -16,6 +16,7 @@
  */
 package com.alipay.sofa.runtime.proxy;
 
+import com.alipay.sofa.runtime.spring.singleton.SingletonSofaPostProcessor;
 import org.springframework.aop.framework.ProxyFactoryBean;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactoryUtils;
@@ -32,6 +33,7 @@ import org.springframework.core.PriorityOrdered;
  * @author ruoshan
  * @since 3.12.0
  */
+@SingletonSofaPostProcessor
 public class ProxyBeanFactoryPostProcessor implements BeanDefinitionRegistryPostProcessor,
                                           PriorityOrdered {
 

--- a/sofa-boot-project/sofa-boot-core/runtime-sofa-boot/src/main/java/com/alipay/sofa/runtime/spring/JvmFilterPostProcessor.java
+++ b/sofa-boot-project/sofa-boot-core/runtime-sofa-boot/src/main/java/com/alipay/sofa/runtime/spring/JvmFilterPostProcessor.java
@@ -19,6 +19,7 @@ package com.alipay.sofa.runtime.spring;
 import com.alipay.sofa.runtime.SofaRuntimeUtils;
 import com.alipay.sofa.runtime.filter.JvmFilterHolder;
 import com.alipay.sofa.runtime.filter.JvmFilter;
+import com.alipay.sofa.runtime.spring.singleton.SingletonSofaPostProcessor;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.core.PriorityOrdered;
@@ -27,6 +28,7 @@ import org.springframework.core.PriorityOrdered;
  * @author <a href="mailto:guaner.zzx@alipay.com">Alaneuler</a>
  * Created on 2020/8/18
  */
+@SingletonSofaPostProcessor
 public class JvmFilterPostProcessor implements BeanPostProcessor, PriorityOrdered {
     @Override
     public Object postProcessAfterInitialization(Object bean, String beanName)

--- a/sofa-boot-project/sofa-boot-core/runtime-sofa-boot/src/main/java/com/alipay/sofa/runtime/spring/RuntimeContextBeanFactoryPostProcessor.java
+++ b/sofa-boot-project/sofa-boot-core/runtime-sofa-boot/src/main/java/com/alipay/sofa/runtime/spring/RuntimeContextBeanFactoryPostProcessor.java
@@ -43,6 +43,10 @@ public class RuntimeContextBeanFactoryPostProcessor implements BeanFactoryPostPr
     private SofaRuntimeContext      sofaRuntimeContext;
     private ApplicationContext      applicationContext;
 
+    public RuntimeContextBeanFactoryPostProcessor() {
+    }
+
+    @Deprecated
     public RuntimeContextBeanFactoryPostProcessor(BindingAdapterFactory bindingAdapterFactory,
                                                   BindingConverterFactory bindingConverterFactory,
                                                   SofaRuntimeContext sofaRuntimeContext) {
@@ -77,5 +81,11 @@ public class RuntimeContextBeanFactoryPostProcessor implements BeanFactoryPostPr
     @Override
     public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
         this.applicationContext = applicationContext;
+        this.bindingAdapterFactory = applicationContext.getBean("bindingAdapterFactory",
+            BindingAdapterFactory.class);
+        this.bindingConverterFactory = applicationContext.getBean("bindingConverterFactory",
+            BindingConverterFactory.class);
+        this.sofaRuntimeContext = applicationContext.getBean("sofaRuntimeContext",
+            SofaRuntimeContext.class);
     }
 }

--- a/sofa-boot-project/sofa-boot-core/runtime-sofa-boot/src/main/java/com/alipay/sofa/runtime/spring/ServiceBeanFactoryPostProcessor.java
+++ b/sofa-boot-project/sofa-boot-core/runtime-sofa-boot/src/main/java/com/alipay/sofa/runtime/spring/ServiceBeanFactoryPostProcessor.java
@@ -88,6 +88,10 @@ public class ServiceBeanFactoryPostProcessor implements BeanDefinitionRegistryPo
     private BindingConverterFactory bindingConverterFactory;
     private Environment             environment;
 
+    public ServiceBeanFactoryPostProcessor() {
+    }
+
+    @Deprecated
     public ServiceBeanFactoryPostProcessor(SofaRuntimeContext sofaRuntimeContext,
                                            BindingConverterFactory bindingConverterFactory) {
         this.sofaRuntimeContext = sofaRuntimeContext;
@@ -382,6 +386,10 @@ public class ServiceBeanFactoryPostProcessor implements BeanDefinitionRegistryPo
     @Override
     public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
         this.applicationContext = applicationContext;
+        this.sofaRuntimeContext = applicationContext.getBean("sofaRuntimeContext",
+            SofaRuntimeContext.class);
+        this.bindingConverterFactory = applicationContext.getBean("bindingConverterFactory",
+            BindingConverterFactory.class);
     }
 
     @Override

--- a/sofa-boot-project/sofa-boot-core/runtime-sofa-boot/src/main/java/com/alipay/sofa/runtime/spring/SofaShareBeanFactoryPostProcessor.java
+++ b/sofa-boot-project/sofa-boot-core/runtime-sofa-boot/src/main/java/com/alipay/sofa/runtime/spring/SofaShareBeanFactoryPostProcessor.java
@@ -16,10 +16,10 @@
  */
 package com.alipay.sofa.runtime.spring;
 
+import com.alipay.sofa.boot.constant.SofaBootConstants;
 import com.alipay.sofa.boot.util.BeanDefinitionUtil;
 import com.alipay.sofa.runtime.spring.share.SofaPostProcessorShareManager;
 import com.alipay.sofa.runtime.spring.share.UnshareSofaPostProcessor;
-import com.alipay.sofa.runtime.spring.singleton.SingletonSofaPostProcessor;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
@@ -30,8 +30,6 @@ import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.EnvironmentAware;
 import org.springframework.context.annotation.ConfigurationClassPostProcessor;
 import org.springframework.core.annotation.Order;
-
-import com.alipay.sofa.boot.constant.SofaBootConstants;
 import org.springframework.core.env.Environment;
 
 import java.util.Arrays;

--- a/sofa-boot-project/sofa-boot-core/runtime-sofa-boot/src/main/java/com/alipay/sofa/runtime/spring/SofaShareBeanFactoryPostProcessor.java
+++ b/sofa-boot-project/sofa-boot-core/runtime-sofa-boot/src/main/java/com/alipay/sofa/runtime/spring/SofaShareBeanFactoryPostProcessor.java
@@ -18,6 +18,7 @@ package com.alipay.sofa.runtime.spring;
 
 import com.alipay.sofa.boot.util.BeanDefinitionUtil;
 import com.alipay.sofa.runtime.spring.share.SofaPostProcessorShareManager;
+import com.alipay.sofa.runtime.spring.singleton.SingletonSofaPostProcessor;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
@@ -44,6 +45,7 @@ import java.util.Set;
  * @author xuanbei 18/3/26
  */
 @Order
+@SingletonSofaPostProcessor
 public class SofaShareBeanFactoryPostProcessor implements BeanFactoryPostProcessor,
                                               EnvironmentAware, ApplicationContextAware {
     /** spring will add automatically  **/

--- a/sofa-boot-project/sofa-boot-core/runtime-sofa-boot/src/main/java/com/alipay/sofa/runtime/spring/SofaShareBeanFactoryPostProcessor.java
+++ b/sofa-boot-project/sofa-boot-core/runtime-sofa-boot/src/main/java/com/alipay/sofa/runtime/spring/SofaShareBeanFactoryPostProcessor.java
@@ -23,6 +23,8 @@ import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
 import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.EnvironmentAware;
 import org.springframework.context.annotation.ConfigurationClassPostProcessor;
 import org.springframework.core.annotation.Order;
@@ -43,7 +45,7 @@ import java.util.Set;
  */
 @Order
 public class SofaShareBeanFactoryPostProcessor implements BeanFactoryPostProcessor,
-                                              EnvironmentAware {
+                                              EnvironmentAware, ApplicationContextAware {
     /** spring will add automatically  **/
     private final String[]                whiteNameList = new String[] {
             ConfigurationClassPostProcessor.class.getName() + ".importAwareProcessor",
@@ -54,6 +56,10 @@ public class SofaShareBeanFactoryPostProcessor implements BeanFactoryPostProcess
 
     private Boolean                       isShareParentContextPostProcessors;
 
+    public SofaShareBeanFactoryPostProcessor() {
+    }
+
+    @Deprecated
     public SofaShareBeanFactoryPostProcessor(SofaPostProcessorShareManager shareManager) {
         this.sofaPostProcessorShareManager = shareManager;
     }
@@ -80,7 +86,7 @@ public class SofaShareBeanFactoryPostProcessor implements BeanFactoryPostProcess
         Set<String> allBeanDefinitionNames = new HashSet<>(Arrays.asList(beanFactory
             .getBeanDefinitionNames()));
 
-        String[] beanNamesForType = beanFactory.getBeanNamesForType(type);
+        String[] beanNamesForType = beanFactory.getBeanNamesForType(type, true, false);
 
         for (String beanName : beanNamesForType) {
             if (notInWhiteNameList(beanName) && allBeanDefinitionNames.contains(beanName)) {
@@ -111,5 +117,11 @@ public class SofaShareBeanFactoryPostProcessor implements BeanFactoryPostProcess
         this.isShareParentContextPostProcessors = environment.getProperty(
             SofaBootConstants.SOFABOOT_SHARE_PARENT_CONTEXT_POST_PROCESSOR_ENABLED, Boolean.class,
             SofaBootConstants.SOFABOOT_SHARE_PARENT_CONTEXT_POST_PROCESSOR_DEFAULT_ENABLED);
+    }
+
+    @Override
+    public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+        this.sofaPostProcessorShareManager = applicationContext.getBean(
+            "sofaModulePostProcessorShareManager", SofaPostProcessorShareManager.class);
     }
 }

--- a/sofa-boot-project/sofa-boot-core/runtime-sofa-boot/src/main/java/com/alipay/sofa/runtime/spring/SofaShareBeanFactoryPostProcessor.java
+++ b/sofa-boot-project/sofa-boot-core/runtime-sofa-boot/src/main/java/com/alipay/sofa/runtime/spring/SofaShareBeanFactoryPostProcessor.java
@@ -18,6 +18,7 @@ package com.alipay.sofa.runtime.spring;
 
 import com.alipay.sofa.boot.util.BeanDefinitionUtil;
 import com.alipay.sofa.runtime.spring.share.SofaPostProcessorShareManager;
+import com.alipay.sofa.runtime.spring.share.UnshareSofaPostProcessor;
 import com.alipay.sofa.runtime.spring.singleton.SingletonSofaPostProcessor;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.config.BeanDefinition;
@@ -45,7 +46,7 @@ import java.util.Set;
  * @author xuanbei 18/3/26
  */
 @Order
-@SingletonSofaPostProcessor
+@UnshareSofaPostProcessor
 public class SofaShareBeanFactoryPostProcessor implements BeanFactoryPostProcessor,
                                               EnvironmentAware, ApplicationContextAware {
     /** spring will add automatically  **/

--- a/sofa-boot-project/sofa-boot-core/runtime-sofa-boot/src/main/java/com/alipay/sofa/runtime/spring/share/SofaPostProcessorShareManager.java
+++ b/sofa-boot-project/sofa-boot-core/runtime-sofa-boot/src/main/java/com/alipay/sofa/runtime/spring/share/SofaPostProcessorShareManager.java
@@ -16,6 +16,10 @@
  */
 package com.alipay.sofa.runtime.spring.share;
 
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.support.AbstractApplicationContext;
 
 import java.util.List;
@@ -25,17 +29,26 @@ import java.util.concurrent.CopyOnWriteArrayList;
 /**
  * Created by TomorJM on 2019-10-09.
  */
-public class SofaPostProcessorShareManager {
+public class SofaPostProcessorShareManager implements ApplicationContextAware, InitializingBean {
 
     private AbstractApplicationContext context;
 
-    private static List<Class>         filterClassList    = new CopyOnWriteArrayList<>();
+    private List<Class>                filterClassList    = new CopyOnWriteArrayList<>();
 
-    private static List<String>        filterBeanNameList = new CopyOnWriteArrayList<>();
+    private List<String>               filterBeanNameList = new CopyOnWriteArrayList<>();
 
+    public SofaPostProcessorShareManager() {
+    }
+
+    @Deprecated
     public SofaPostProcessorShareManager(AbstractApplicationContext applicationContext) {
         this.context = applicationContext;
-        Map<String, SofaPostProcessorShareFilter> map = context.getBeansOfType(SofaPostProcessorShareFilter.class);
+    }
+
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        Map<String, SofaPostProcessorShareFilter> map = context.getBeansOfType(SofaPostProcessorShareFilter.class,
+                true, false);
         map.forEach((k, v) -> {
             this.filterClassList.addAll(v.filterBeanFactoryPostProcessorClass());
             this.filterClassList.addAll(v.filterBeanPostProcessorClass());
@@ -53,4 +66,8 @@ public class SofaPostProcessorShareManager {
         return this.filterBeanNameList.contains(beanName);
     }
 
+    @Override
+    public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+        this.context = (AbstractApplicationContext) applicationContext;
+    }
 }

--- a/sofa-boot-project/sofa-boot-core/runtime-sofa-boot/src/main/java/com/alipay/sofa/runtime/spring/singleton/SingletonSofaPostProcessor.java
+++ b/sofa-boot-project/sofa-boot-core/runtime-sofa-boot/src/main/java/com/alipay/sofa/runtime/spring/singleton/SingletonSofaPostProcessor.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.runtime.spring.singleton;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Use this annotation to tag BeanFactoryPostProcessor/BeanPostProcessor, which will share singleton in modules.
+ * @author huzijie
+ * @version SingletonSofaPostProcessor.java, v 0.1 2022年10月24日 4:24 PM huzijie Exp $
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.TYPE })
+@Inherited
+public @interface SingletonSofaPostProcessor {
+}

--- a/sofa-boot-project/sofa-boot-core/runtime-sofa-boot/src/test/java/com/alipay/sofa/runtime/test/configuration/RuntimeConfiguration.java
+++ b/sofa-boot-project/sofa-boot-core/runtime-sofa-boot/src/test/java/com/alipay/sofa/runtime/test/configuration/RuntimeConfiguration.java
@@ -102,17 +102,13 @@ public class RuntimeConfiguration {
     }
 
     @Bean
-    public static RuntimeContextBeanFactoryPostProcessor runtimeContextBeanFactoryPostProcessor(BindingAdapterFactory bindingAdapterFactory,
-                                                                                                BindingConverterFactory bindingConverterFactory,
-                                                                                                SofaRuntimeContext sofaRuntimeContext) {
-        return new RuntimeContextBeanFactoryPostProcessor(bindingAdapterFactory,
-            bindingConverterFactory, sofaRuntimeContext);
+    public static RuntimeContextBeanFactoryPostProcessor runtimeContextBeanFactoryPostProcessor() {
+        return new RuntimeContextBeanFactoryPostProcessor();
     }
 
     @Bean
-    public static ServiceBeanFactoryPostProcessor serviceBeanFactoryPostProcessor(SofaRuntimeContext sofaRuntimeContext,
-                                                                                  BindingConverterFactory bindingConverterFactory) {
-        return new ServiceBeanFactoryPostProcessor(sofaRuntimeContext, bindingConverterFactory);
+    public static ServiceBeanFactoryPostProcessor serviceBeanFactoryPostProcessor() {
+        return new ServiceBeanFactoryPostProcessor();
     }
 
     public static <T> Set<T> getClassesByServiceLoader(Class<T> clazz) {

--- a/sofa-boot-project/sofa-boot-core/startup-sofa-boot/src/test/java/com/alipay/sofa/startup/test/configuration/SofaStartupIsleAutoConfiguration.java
+++ b/sofa-boot-project/sofa-boot-core/startup-sofa-boot/src/test/java/com/alipay/sofa/startup/test/configuration/SofaStartupIsleAutoConfiguration.java
@@ -19,16 +19,21 @@ package com.alipay.sofa.startup.test.configuration;
 import com.alipay.sofa.isle.ApplicationRuntimeModel;
 import com.alipay.sofa.isle.profile.DefaultSofaModuleProfileChecker;
 import com.alipay.sofa.isle.profile.SofaModuleProfileChecker;
-import com.alipay.sofa.isle.spring.config.SofaModuleProperties;
-import com.alipay.sofa.runtime.spring.SofaShareBeanFactoryPostProcessor;
 import com.alipay.sofa.isle.spring.SofaModuleContextLifecycle;
-import com.alipay.sofa.runtime.spring.share.SofaPostProcessorShareManager;
-import com.alipay.sofa.isle.stage.*;
+import com.alipay.sofa.isle.spring.config.SofaModuleProperties;
+import com.alipay.sofa.isle.stage.DefaultPipelineContext;
+import com.alipay.sofa.isle.stage.ModelCreatingStage;
+import com.alipay.sofa.isle.stage.ModuleLogOutputStage;
+import com.alipay.sofa.isle.stage.PipelineContext;
+import com.alipay.sofa.isle.stage.PipelineStage;
+import com.alipay.sofa.isle.stage.SpringContextInstallStage;
 import com.alipay.sofa.runtime.SofaFramework;
 import com.alipay.sofa.runtime.client.impl.ClientFactoryImpl;
 import com.alipay.sofa.runtime.component.impl.StandardSofaRuntimeManager;
 import com.alipay.sofa.runtime.spi.client.ClientFactoryInternal;
 import com.alipay.sofa.runtime.spi.component.SofaRuntimeManager;
+import com.alipay.sofa.runtime.spring.SofaShareBeanFactoryPostProcessor;
+import com.alipay.sofa.runtime.spring.share.SofaPostProcessorShareManager;
 import com.alipay.sofa.startup.StartupReporter;
 import com.alipay.sofa.startup.stage.isle.StartupModelCreatingStage;
 import com.alipay.sofa.startup.stage.isle.StartupSpringContextInstallStage;
@@ -98,14 +103,14 @@ public class SofaStartupIsleAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    public SofaPostProcessorShareManager sofaModulePostProcessorShareManager(ApplicationContext applicationContext) {
-        return new SofaPostProcessorShareManager((AbstractApplicationContext) applicationContext);
+    public SofaPostProcessorShareManager sofaModulePostProcessorShareManager() {
+        return new SofaPostProcessorShareManager();
     }
 
     @Bean
     @ConditionalOnMissingBean
-    public static SofaShareBeanFactoryPostProcessor sofaModuleBeanFactoryPostProcessor(SofaPostProcessorShareManager shareManager) {
-        return new SofaShareBeanFactoryPostProcessor(shareManager);
+    public static SofaShareBeanFactoryPostProcessor sofaModuleBeanFactoryPostProcessor() {
+        return new SofaShareBeanFactoryPostProcessor();
     }
 
     @Bean(destroyMethod = "")

--- a/sofa-boot-project/sofa-boot-core/startup-sofa-boot/src/test/java/com/alipay/sofa/startup/test/spring/RuntimeConfiguration.java
+++ b/sofa-boot-project/sofa-boot-core/startup-sofa-boot/src/test/java/com/alipay/sofa/startup/test/spring/RuntimeConfiguration.java
@@ -94,17 +94,13 @@ public class RuntimeConfiguration {
     }
 
     @Bean
-    public static RuntimeContextBeanFactoryPostProcessor runtimeContextBeanFactoryPostProcessor(BindingAdapterFactory bindingAdapterFactory,
-                                                                                                BindingConverterFactory bindingConverterFactory,
-                                                                                                SofaRuntimeContext sofaRuntimeContext) {
-        return new RuntimeContextBeanFactoryPostProcessor(bindingAdapterFactory,
-            bindingConverterFactory, sofaRuntimeContext);
+    public static RuntimeContextBeanFactoryPostProcessor runtimeContextBeanFactoryPostProcessor() {
+        return new RuntimeContextBeanFactoryPostProcessor();
     }
 
     @Bean
-    public static ServiceBeanFactoryPostProcessor serviceBeanFactoryPostProcessor(SofaRuntimeContext sofaRuntimeContext,
-                                                                                  BindingConverterFactory bindingConverterFactory) {
-        return new ServiceBeanFactoryPostProcessor(sofaRuntimeContext, bindingConverterFactory);
+    public static ServiceBeanFactoryPostProcessor serviceBeanFactoryPostProcessor() {
+        return new ServiceBeanFactoryPostProcessor();
     }
 
     public static <T> Set<T> getClassesByServiceLoader(Class<T> clazz) {


### PR DESCRIPTION
1. 支持通过 @SingletonSofaPostProcessor 注解指定 PostProcessor 以单例形式共享；
2. 优化一些 PostProcessor 实现，减少 byType 注入，避免触发 FactoryBean 提前初始化