### PR TITLE
upgrade javassit version to 3.29.2-GA ,rpc smoke tests use javassist

### DIFF
--- a/sofa-boot-project/sofaboot-dependencies/pom.xml
+++ b/sofa-boot-project/sofaboot-dependencies/pom.xml
@@ -33,7 +33,7 @@
         <spring.cloud.starter.version>4.0.0</spring.cloud.starter.version>
         <asm.version>9.4</asm.version>
         <fastjson.version>1.2.83</fastjson.version>
-        <javassist.version>3.19.0-GA</javassist.version>
+        <javassist.version>3.29.2-GA</javassist.version>
         <protobuf.version>3.22.2</protobuf.version>
         <xerces.version>2.12.2</xerces.version>
         <guice.version>3.0</guice.version>

--- a/sofa-boot-tests/sofa-boot-smoke-tests/sofa-boot-smoke-tests-rpc/src/main/resources/META-INF/sofa-rpc/rpc-config.json
+++ b/sofa-boot-tests/sofa-boot-smoke-tests/sofa-boot-smoke-tests-rpc/src/main/resources/META-INF/sofa-rpc/rpc-config.json
@@ -1,3 +1,5 @@
 {
-  "default.proxy": "jdk"
+  "default.proxy": "javassist",
+  "rpc.config.order": 1000,
+  "consumer.address.wait": 1
 }


### PR DESCRIPTION
upgrade javassit version to 3.29.2-GA ,rpc smoke tests use javassist