### PR TITLE
fix toolkit-common-logging config bug

### DIFF
--- a/sofa-boot-project/sofa-boot-core/log-sofa-boot/src/main/java/com/alipay/sofa/boot/logging/LogEnvironmentPreparingListener.java
+++ b/sofa-boot-project/sofa-boot-core/log-sofa-boot/src/main/java/com/alipay/sofa/boot/logging/LogEnvironmentPreparingListener.java
@@ -46,8 +46,8 @@ public class LogEnvironmentPreparingListener
 
     @Override
     public int getOrder() {
-        // Must be invoked after ConfigFileApplicationListener
-        return Ordered.HIGHEST_PRECEDENCE + 20;
+        // Must be invoked after ConfigFileApplicationListener, and before SofaConfigSourceSupportListener
+        return Ordered.HIGHEST_PRECEDENCE + 12;
     }
 
     private void prepare(ConfigurableEnvironment environment) {

--- a/sofa-boot-project/sofa-boot/src/main/java/com/alipay/sofa/boot/listener/SofaConfigSourceSupportListener.java
+++ b/sofa-boot-project/sofa-boot/src/main/java/com/alipay/sofa/boot/listener/SofaConfigSourceSupportListener.java
@@ -19,6 +19,7 @@ package com.alipay.sofa.boot.listener;
 import com.alipay.sofa.common.config.SofaConfigs;
 import com.alipay.sofa.common.config.source.AbstractConfigSource;
 import org.springframework.boot.context.event.ApplicationEnvironmentPreparedEvent;
+import org.springframework.boot.context.logging.LoggingApplicationListener;
 import org.springframework.context.ApplicationListener;
 import org.springframework.core.Ordered;
 import org.springframework.core.env.ConfigurableEnvironment;
@@ -63,6 +64,6 @@ public class SofaConfigSourceSupportListener
 
     @Override
     public int getOrder() {
-        return LOWEST_PRECEDENCE;
+        return LoggingApplicationListener.DEFAULT_ORDER - 10;
     }
 }

--- a/sofa-boot-project/sofa-boot/src/main/java/com/alipay/sofa/boot/listener/SofaConfigSourceSupportListener.java
+++ b/sofa-boot-project/sofa-boot/src/main/java/com/alipay/sofa/boot/listener/SofaConfigSourceSupportListener.java
@@ -34,7 +34,7 @@ public class SofaConfigSourceSupportListener
                                             implements
                                             ApplicationListener<ApplicationEnvironmentPreparedEvent>,
                                             Ordered {
-    private static final int SOFA_BOOT_CONFIG_SOURCE_ORDER = LOWEST_PRECEDENCE;
+    private static final int SOFA_BOOT_CONFIG_SOURCE_ORDER = LoggingApplicationListener.DEFAULT_ORDER - 5;
 
     @Override
     public void onApplicationEvent(ApplicationEnvironmentPreparedEvent event) {
@@ -64,6 +64,6 @@ public class SofaConfigSourceSupportListener
 
     @Override
     public int getOrder() {
-        return LoggingApplicationListener.DEFAULT_ORDER - 10;
+        return LoggingApplicationListener.DEFAULT_ORDER - 5;
     }
 }


### PR DESCRIPTION
raise SofaConfigSourceSupportListener order to "LoggingApplicationListener.DEFAULT_ORDER - 10" to fix toolkit-common-logging config bug