### PR TITLE
optimize getBiz method by reduce invoke Map.toArray() (#1286)

### DIFF
--- a/sofa-boot-project/sofa-boot-core/ark-sofa-boot/src/main/java/com/alipay/sofa/boot/ark/invoke/DynamicJvmServiceProxyFinder.java
+++ b/sofa-boot-project/sofa-boot-core/ark-sofa-boot/src/main/java/com/alipay/sofa/boot/ark/invoke/DynamicJvmServiceProxyFinder.java
@@ -251,13 +251,8 @@ public class DynamicJvmServiceProxyFinder {
         if (getInstance().bizManagerService == null) {
             return null;
         }
-
-        for (Biz biz : getInstance().bizManagerService.getBizInOrder()) {
-            if (biz.getBizClassLoader().equals(sofaRuntimeManager.getAppClassLoader())) {
-                return biz;
-            }
-        }
-        return null;
+        return getInstance().bizManagerService.getBizByClassLoader(sofaRuntimeManager
+            .getAppClassLoader());
     }
 
     public boolean isHasFinishStartup() {

--- a/sofa-boot-project/sofa-boot-core/ark-sofa-boot/src/test/java/com/alipay/sofa/boot/ark/MockBizManagerService.java
+++ b/sofa-boot-project/sofa-boot-core/ark-sofa-boot/src/test/java/com/alipay/sofa/boot/ark/MockBizManagerService.java
@@ -65,6 +65,11 @@ public class MockBizManagerService implements BizManagerService {
 
     @Override
     public Biz getBizByClassLoader(ClassLoader classLoader) {
+        for (Biz biz : bizList) {
+            if (biz.getBizClassLoader().equals(classLoader)) {
+                return biz;
+            }
+        }
         return null;
     }
 


### PR DESCRIPTION
使用`getBizByClassLoader` 方法替换`getBizInOrder`方法。减少 Map.toArray 调用次数，和冗余的排序操作；