### PR TITLE
fix #1276  after healthcheck double check success, register async

### DIFF
--- a/sofa-boot-project/sofa-boot-actuator-autoconfigure/src/main/java/com/alipay/sofa/boot/actuator/autoconfigure/rpc/RpcActuatorAutoConfiguration.java
+++ b/sofa-boot-project/sofa-boot-actuator-autoconfigure/src/main/java/com/alipay/sofa/boot/actuator/autoconfigure/rpc/RpcActuatorAutoConfiguration.java
@@ -21,7 +21,6 @@ import com.alipay.sofa.boot.actuator.health.ReadinessEndpoint;
 import com.alipay.sofa.boot.actuator.rpc.HealthCheckProviderConfigDelayRegisterChecker;
 import com.alipay.sofa.boot.actuator.rpc.RpcAfterHealthCheckCallback;
 import com.alipay.sofa.boot.actuator.rpc.SofaRpcEndpoint;
-import com.alipay.sofa.boot.autoconfigure.rpc.SofaBootRpcProperties;
 import com.alipay.sofa.boot.autoconfigure.rpc.SofaRpcAutoConfiguration;
 import com.alipay.sofa.rpc.boot.context.RpcStartApplicationListener;
 import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
@@ -46,19 +45,6 @@ public class RpcActuatorAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean
     @ConditionalOnAvailableEndpoint(endpoint = ReadinessEndpoint.class)
-    public HealthCheckProviderConfigDelayRegisterChecker providerConfigDelayRegisterCheckerSupport(ReadinessCheckListener readinessCheckListener,
-                                                                                                   SofaBootRpcProperties sofaBootRpcProperties) {
-        HealthCheckProviderConfigDelayRegisterChecker healthCheckProviderConfigDelayRegisterChecker = new HealthCheckProviderConfigDelayRegisterChecker();
-        healthCheckProviderConfigDelayRegisterChecker
-            .setReadinessCheckListener(readinessCheckListener);
-        healthCheckProviderConfigDelayRegisterChecker.setEnableDelayRegister(sofaBootRpcProperties
-            .getEnableDelayRegister());
-        return healthCheckProviderConfigDelayRegisterChecker;
-    }
-
-    @Bean
-    @ConditionalOnMissingBean
-    @ConditionalOnAvailableEndpoint(endpoint = ReadinessEndpoint.class)
     public RpcAfterHealthCheckCallback rpcAfterHealthCheckCallback(RpcStartApplicationListener rpcStartApplicationListener) {
         return new RpcAfterHealthCheckCallback(rpcStartApplicationListener);
     }
@@ -68,5 +54,12 @@ public class RpcActuatorAutoConfiguration {
     @ConditionalOnAvailableEndpoint(endpoint = SofaRpcEndpoint.class)
     public SofaRpcEndpoint sofaRpcEndPoint() {
         return new SofaRpcEndpoint();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    @ConditionalOnAvailableEndpoint(endpoint = ReadinessEndpoint.class)
+    public HealthCheckProviderConfigDelayRegisterChecker healthCheckProviderConfigDelayRegisterChecker(ReadinessCheckListener readinessCheckListener) {
+        return new HealthCheckProviderConfigDelayRegisterChecker(readinessCheckListener);
     }
 }

--- a/sofa-boot-project/sofa-boot-actuator-autoconfigure/src/main/java/com/alipay/sofa/boot/actuator/autoconfigure/rpc/RpcActuatorAutoConfiguration.java
+++ b/sofa-boot-project/sofa-boot-actuator-autoconfigure/src/main/java/com/alipay/sofa/boot/actuator/autoconfigure/rpc/RpcActuatorAutoConfiguration.java
@@ -59,6 +59,7 @@ public class RpcActuatorAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean
     @ConditionalOnAvailableEndpoint(endpoint = ReadinessEndpoint.class)
+    @ConditionalOnBean(ReadinessCheckListener.class)
     public HealthCheckProviderConfigDelayRegisterChecker healthCheckProviderConfigDelayRegisterChecker(ReadinessCheckListener readinessCheckListener) {
         return new HealthCheckProviderConfigDelayRegisterChecker(readinessCheckListener);
     }

--- a/sofa-boot-project/sofa-boot-actuator-autoconfigure/src/main/java/com/alipay/sofa/boot/actuator/autoconfigure/rpc/RpcActuatorAutoConfiguration.java
+++ b/sofa-boot-project/sofa-boot-actuator-autoconfigure/src/main/java/com/alipay/sofa/boot/actuator/autoconfigure/rpc/RpcActuatorAutoConfiguration.java
@@ -16,9 +16,12 @@
  */
 package com.alipay.sofa.boot.actuator.autoconfigure.rpc;
 
+import com.alipay.sofa.boot.actuator.health.ReadinessCheckListener;
 import com.alipay.sofa.boot.actuator.health.ReadinessEndpoint;
+import com.alipay.sofa.boot.actuator.rpc.HealthCheckProviderConfigDelayRegisterChecker;
 import com.alipay.sofa.boot.actuator.rpc.RpcAfterHealthCheckCallback;
 import com.alipay.sofa.boot.actuator.rpc.SofaRpcEndpoint;
+import com.alipay.sofa.boot.autoconfigure.rpc.SofaBootRpcProperties;
 import com.alipay.sofa.boot.autoconfigure.rpc.SofaRpcAutoConfiguration;
 import com.alipay.sofa.rpc.boot.context.RpcStartApplicationListener;
 import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
@@ -39,6 +42,19 @@ import org.springframework.context.annotation.Bean;
 @ConditionalOnClass(RpcStartApplicationListener.class)
 @ConditionalOnBean(RpcStartApplicationListener.class)
 public class RpcActuatorAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean
+    @ConditionalOnAvailableEndpoint(endpoint = ReadinessEndpoint.class)
+    public HealthCheckProviderConfigDelayRegisterChecker providerConfigDelayRegisterCheckerSupport(ReadinessCheckListener readinessCheckListener,
+                                                                                                   SofaBootRpcProperties sofaBootRpcProperties) {
+        HealthCheckProviderConfigDelayRegisterChecker healthCheckProviderConfigDelayRegisterChecker = new HealthCheckProviderConfigDelayRegisterChecker();
+        healthCheckProviderConfigDelayRegisterChecker
+            .setReadinessCheckListener(readinessCheckListener);
+        healthCheckProviderConfigDelayRegisterChecker.setEnableDelayRegister(sofaBootRpcProperties
+            .getEnableDelayRegister());
+        return healthCheckProviderConfigDelayRegisterChecker;
+    }
 
     @Bean
     @ConditionalOnMissingBean

--- a/sofa-boot-project/sofa-boot-actuator-autoconfigure/src/test/java/com/alipay/sofa/boot/actuator/autoconfigure/rpc/RpcActuatorAutoConfigurationTests.java
+++ b/sofa-boot-project/sofa-boot-actuator-autoconfigure/src/test/java/com/alipay/sofa/boot/actuator/autoconfigure/rpc/RpcActuatorAutoConfigurationTests.java
@@ -16,6 +16,7 @@
  */
 package com.alipay.sofa.boot.actuator.autoconfigure.rpc;
 
+import com.alipay.sofa.boot.actuator.autoconfigure.health.ReadinessAutoConfiguration;
 import com.alipay.sofa.boot.actuator.health.HealthCheckerProcessor;
 import com.alipay.sofa.boot.actuator.health.HealthIndicatorProcessor;
 import com.alipay.sofa.boot.actuator.health.ReadinessCheckCallbackProcessor;
@@ -49,14 +50,21 @@ public class RpcActuatorAutoConfigurationTests {
                                                                  "management.endpoints.web.exposure.include=readiness,rpc");
 
     @Test
+    void runShouldHaveHealthCheckProviderConfigDelayRegisterChecker() {
+        this.contextRunner
+                .withUserConfiguration(ReadinessAutoConfiguration.class)
+                .withBean(RpcStartApplicationListener.class)
+                .run((context) -> assertThat(context)
+                        .hasSingleBean(HealthCheckProviderConfigDelayRegisterChecker.class));
+    }
+
+    @Test
     void runShouldHaveRpcActuatorBeans() {
         this.contextRunner
                 .withBean(RpcStartApplicationListener.class)
-                .withBean(MockReadinessCheckListenerConfiguration.class)
                 .run((context) -> assertThat(context)
                         .hasSingleBean(RpcAfterHealthCheckCallback.class)
-                        .hasSingleBean(SofaRpcEndpoint.class)
-                        .hasSingleBean(HealthCheckProviderConfigDelayRegisterChecker.class));
+                        .hasSingleBean(SofaRpcEndpoint.class));
     }
 
     @Test
@@ -66,8 +74,7 @@ public class RpcActuatorAutoConfigurationTests {
                 .withPropertyValues("management.endpoints.web.exposure.include=info")
                 .run((context) -> assertThat(context)
                         .doesNotHaveBean(RpcAfterHealthCheckCallback.class)
-                        .doesNotHaveBean(SofaRpcEndpoint.class)
-                        .doesNotHaveBean(HealthCheckProviderConfigDelayRegisterChecker.class));
+                        .doesNotHaveBean(SofaRpcEndpoint.class));
     }
 
     @Test
@@ -77,8 +84,7 @@ public class RpcActuatorAutoConfigurationTests {
                 .withClassLoader(new FilteredClassLoader(RpcStartApplicationListener.class))
                 .run((context) -> assertThat(context)
                         .doesNotHaveBean(RpcAfterHealthCheckCallback.class)
-                        .doesNotHaveBean(SofaRpcEndpoint.class)
-                        .doesNotHaveBean(HealthCheckProviderConfigDelayRegisterChecker.class));
+                        .doesNotHaveBean(SofaRpcEndpoint.class));
     }
 
     @Test
@@ -86,8 +92,7 @@ public class RpcActuatorAutoConfigurationTests {
         this.contextRunner
                 .run((context) -> assertThat(context)
                         .doesNotHaveBean(RpcAfterHealthCheckCallback.class)
-                        .doesNotHaveBean(SofaRpcEndpoint.class)
-                        .doesNotHaveBean(HealthCheckProviderConfigDelayRegisterChecker.class));
+                        .doesNotHaveBean(SofaRpcEndpoint.class));
     }
 
     static class MockReadinessCheckListenerConfiguration {

--- a/sofa-boot-project/sofa-boot-actuator/src/main/java/com/alipay/sofa/boot/actuator/extension/ProviderConfigDelayRegisterCheckerSupport.java
+++ b/sofa-boot-project/sofa-boot-actuator/src/main/java/com/alipay/sofa/boot/actuator/extension/ProviderConfigDelayRegisterCheckerSupport.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.boot.actuator.extension;
+
+import com.alipay.sofa.boot.actuator.health.ReadinessCheckListener;
+import com.alipay.sofa.rpc.boot.extension.ProviderConfigDelayRegisterChecker;
+import org.springframework.beans.BeansException;
+import org.springframework.boot.availability.ReadinessState;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+
+public class ProviderConfigDelayRegisterCheckerSupport implements ApplicationContextAware,
+                                                      ProviderConfigDelayRegisterChecker {
+
+    private ApplicationContext applicationContext;
+
+    @Override
+    public boolean isDelayRegisterHealthCheck() {
+        ReadinessCheckListener readinessCheckListener = applicationContext
+            .getBean(ReadinessCheckListener.class);
+        return ReadinessState.ACCEPTING_TRAFFIC.equals(readinessCheckListener.getReadinessState());
+    }
+
+    @Override
+    public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+        this.applicationContext = applicationContext;
+    }
+}

--- a/sofa-boot-project/sofa-boot-actuator/src/main/java/com/alipay/sofa/boot/actuator/rpc/HealthCheckProviderConfigDelayRegisterChecker.java
+++ b/sofa-boot-project/sofa-boot-actuator/src/main/java/com/alipay/sofa/boot/actuator/rpc/HealthCheckProviderConfigDelayRegisterChecker.java
@@ -34,6 +34,6 @@ public class HealthCheckProviderConfigDelayRegisterChecker implements
 
     @Override
     public boolean allowRegister() {
-        return ReadinessState.ACCEPTING_TRAFFIC.equals(readinessCheckListener.getReadinessState());
+        return !ReadinessState.REFUSING_TRAFFIC.equals(readinessCheckListener.getReadinessState());
     }
 }

--- a/sofa-boot-project/sofa-boot-actuator/src/main/java/com/alipay/sofa/boot/actuator/rpc/HealthCheckProviderConfigDelayRegisterChecker.java
+++ b/sofa-boot-project/sofa-boot-actuator/src/main/java/com/alipay/sofa/boot/actuator/rpc/HealthCheckProviderConfigDelayRegisterChecker.java
@@ -14,29 +14,32 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.alipay.sofa.boot.actuator.extension;
+package com.alipay.sofa.boot.actuator.rpc;
 
 import com.alipay.sofa.boot.actuator.health.ReadinessCheckListener;
-import com.alipay.sofa.rpc.boot.extension.ProviderConfigDelayRegisterChecker;
-import org.springframework.beans.BeansException;
+import com.alipay.sofa.rpc.boot.container.ProviderConfigDelayRegisterChecker;
 import org.springframework.boot.availability.ReadinessState;
-import org.springframework.context.ApplicationContext;
-import org.springframework.context.ApplicationContextAware;
 
-public class ProviderConfigDelayRegisterCheckerSupport implements ApplicationContextAware,
-                                                      ProviderConfigDelayRegisterChecker {
+/**
+ * ProviderConfigDelayRegisterChecker的具体实现
+ */
+public class HealthCheckProviderConfigDelayRegisterChecker implements
+                                                          ProviderConfigDelayRegisterChecker {
 
-    private ApplicationContext applicationContext;
+    private ReadinessCheckListener readinessCheckListener;
+
+    private boolean                enableDelayRegister;
 
     @Override
-    public boolean isDelayRegisterHealthCheck() {
-        ReadinessCheckListener readinessCheckListener = applicationContext
-            .getBean(ReadinessCheckListener.class);
+    public boolean allowRegister() {
         return ReadinessState.ACCEPTING_TRAFFIC.equals(readinessCheckListener.getReadinessState());
     }
 
-    @Override
-    public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
-        this.applicationContext = applicationContext;
+    public void setReadinessCheckListener(ReadinessCheckListener readinessCheckListener) {
+        this.readinessCheckListener = readinessCheckListener;
+    }
+
+    public void setEnableDelayRegister(boolean enableDelayRegister) {
+        this.enableDelayRegister = enableDelayRegister;
     }
 }

--- a/sofa-boot-project/sofa-boot-actuator/src/main/java/com/alipay/sofa/boot/actuator/rpc/HealthCheckProviderConfigDelayRegisterChecker.java
+++ b/sofa-boot-project/sofa-boot-actuator/src/main/java/com/alipay/sofa/boot/actuator/rpc/HealthCheckProviderConfigDelayRegisterChecker.java
@@ -28,18 +28,12 @@ public class HealthCheckProviderConfigDelayRegisterChecker implements
 
     private ReadinessCheckListener readinessCheckListener;
 
-    private boolean                enableDelayRegister;
+    public HealthCheckProviderConfigDelayRegisterChecker(ReadinessCheckListener readinessCheckListener) {
+        this.readinessCheckListener = readinessCheckListener;
+    }
 
     @Override
     public boolean allowRegister() {
         return ReadinessState.ACCEPTING_TRAFFIC.equals(readinessCheckListener.getReadinessState());
-    }
-
-    public void setReadinessCheckListener(ReadinessCheckListener readinessCheckListener) {
-        this.readinessCheckListener = readinessCheckListener;
-    }
-
-    public void setEnableDelayRegister(boolean enableDelayRegister) {
-        this.enableDelayRegister = enableDelayRegister;
     }
 }

--- a/sofa-boot-project/sofa-boot-actuator/src/test/java/com/alipay/sofa/boot/actuator/rpc/HealthCheckProviderConfigDelayRegisterCheckerTest.java
+++ b/sofa-boot-project/sofa-boot-actuator/src/test/java/com/alipay/sofa/boot/actuator/rpc/HealthCheckProviderConfigDelayRegisterCheckerTest.java
@@ -25,7 +25,7 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.availability.ReadinessState;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Test for {@link HealthCheckProviderConfigDelayRegisterChecker}
@@ -48,7 +48,7 @@ public class HealthCheckProviderConfigDelayRegisterCheckerTest {
         boolean result = healthCheckProviderConfigDelayRegisterChecker.allowRegister();
 
         // Verify the results
-        assertTrue(result);
+        assertThat(result).isTrue();
     }
 
 }

--- a/sofa-boot-project/sofa-boot-actuator/src/test/java/com/alipay/sofa/boot/actuator/rpc/HealthCheckProviderConfigDelayRegisterCheckerTest.java
+++ b/sofa-boot-project/sofa-boot-actuator/src/test/java/com/alipay/sofa/boot/actuator/rpc/HealthCheckProviderConfigDelayRegisterCheckerTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.boot.actuator.rpc;
+
+import com.alipay.sofa.boot.actuator.health.ReadinessCheckListener;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.availability.ReadinessState;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Test for {@link HealthCheckProviderConfigDelayRegisterChecker}
+ */
+@ExtendWith(MockitoExtension.class)
+public class HealthCheckProviderConfigDelayRegisterCheckerTest {
+
+    @InjectMocks
+    private HealthCheckProviderConfigDelayRegisterChecker healthCheckProviderConfigDelayRegisterChecker;
+
+    @Mock
+    private ReadinessCheckListener                        readinessCheckListener;
+
+    @Test
+    public void testAllowRegister() {
+        // Setup
+        Mockito.doReturn(ReadinessState.ACCEPTING_TRAFFIC).when(readinessCheckListener)
+            .getReadinessState();
+        // Run the test
+        boolean result = healthCheckProviderConfigDelayRegisterChecker.allowRegister();
+
+        // Verify the results
+        assertTrue(result);
+    }
+
+}

--- a/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/rpc/SofaBootRpcProperties.java
+++ b/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/rpc/SofaBootRpcProperties.java
@@ -342,6 +342,19 @@ public class SofaBootRpcProperties implements EnvironmentAware {
 
     private List<String>        providerRegisterBlackList;
 
+    /**
+     * 是否开启延时注册功能
+     */
+    private Boolean             enableDelayRegister;
+
+    public Boolean getEnableDelayRegister() {
+        return enableDelayRegister;
+    }
+
+    public void setEnableDelayRegister(Boolean enableDelayRegister) {
+        this.enableDelayRegister = enableDelayRegister;
+    }
+
     public boolean isEnableAutoPublish() {
         return enableAutoPublish;
     }

--- a/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/rpc/SofaBootRpcProperties.java
+++ b/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/rpc/SofaBootRpcProperties.java
@@ -946,7 +946,7 @@ public class SofaBootRpcProperties implements EnvironmentAware {
         this.providerRegisterBlackList = providerRegisterBlackList;
     }
 
-    public boolean getEnableDelayRegister() {
+    public boolean isEnableDelayRegister() {
         return enableDelayRegister;
     }
 

--- a/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/rpc/SofaBootRpcProperties.java
+++ b/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/rpc/SofaBootRpcProperties.java
@@ -345,15 +345,7 @@ public class SofaBootRpcProperties implements EnvironmentAware {
     /**
      * 是否开启延时注册功能
      */
-    private Boolean             enableDelayRegister;
-
-    public Boolean getEnableDelayRegister() {
-        return enableDelayRegister;
-    }
-
-    public void setEnableDelayRegister(Boolean enableDelayRegister) {
-        this.enableDelayRegister = enableDelayRegister;
-    }
+    private boolean             enableDelayRegister;
 
     public boolean isEnableAutoPublish() {
         return enableAutoPublish;
@@ -952,6 +944,14 @@ public class SofaBootRpcProperties implements EnvironmentAware {
 
     public void setProviderRegisterBlackList(List<String> providerRegisterBlackList) {
         this.providerRegisterBlackList = providerRegisterBlackList;
+    }
+
+    public boolean getEnableDelayRegister() {
+        return enableDelayRegister;
+    }
+
+    public void setEnableDelayRegister(boolean enableDelayRegister) {
+        this.enableDelayRegister = enableDelayRegister;
     }
 
     @Override

--- a/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/rpc/SofaRpcAutoConfiguration.java
+++ b/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/rpc/SofaRpcAutoConfiguration.java
@@ -16,7 +16,6 @@
  */
 package com.alipay.sofa.boot.autoconfigure.rpc;
 
-import com.alipay.sofa.boot.actuator.rpc.HealthCheckProviderConfigDelayRegisterChecker;
 import com.alipay.sofa.boot.autoconfigure.condition.ConditionalOnSwitch;
 import com.alipay.sofa.boot.autoconfigure.rpc.SofaRpcAutoConfiguration.RegistryConfigurationImportSelector;
 import com.alipay.sofa.boot.autoconfigure.runtime.SofaRuntimeAutoConfiguration;
@@ -25,6 +24,7 @@ import com.alipay.sofa.rpc.boot.config.FaultToleranceConfigurator;
 import com.alipay.sofa.rpc.boot.config.RegistryConfigureProcessor;
 import com.alipay.sofa.rpc.boot.container.ConsumerConfigContainer;
 import com.alipay.sofa.rpc.boot.container.ProviderConfigContainer;
+import com.alipay.sofa.rpc.boot.container.ProviderConfigDelayRegisterChecker;
 import com.alipay.sofa.rpc.boot.container.RegistryConfigContainer;
 import com.alipay.sofa.rpc.boot.container.ServerConfigContainer;
 import com.alipay.sofa.rpc.boot.context.RpcStartApplicationListener;
@@ -75,17 +75,16 @@ public class SofaRpcAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean
     public ProviderConfigContainer providerConfigContainer(SofaBootRpcProperties sofaBootRpcProperties,
-                                                           ObjectProvider<HealthCheckProviderConfigDelayRegisterChecker> healthCheckProviderConfigDelayRegisterChecker) {
+                                                           ObjectProvider<ProviderConfigDelayRegisterChecker> providerConfigDelayRegisterCheckers) {
         ProviderConfigContainer providerConfigContainer = new ProviderConfigContainer();
         providerConfigContainer.setProviderRegisterWhiteList(sofaBootRpcProperties
             .getProviderRegisterWhiteList());
         providerConfigContainer.setProviderRegisterBlackList(sofaBootRpcProperties
             .getProviderRegisterBlackList());
-        providerConfigContainer
-            .setProviderConfigDelayRegister(healthCheckProviderConfigDelayRegisterChecker.stream()
-                .collect(Collectors.toList()));
+        providerConfigContainer.setProviderConfigDelayRegister(providerConfigDelayRegisterCheckers
+            .stream().collect(Collectors.toList()));
         providerConfigContainer.setEnableDelayRegister(sofaBootRpcProperties
-            .getEnableDelayRegister());
+            .isEnableDelayRegister());
         return providerConfigContainer;
     }
 

--- a/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/rpc/SofaRpcAutoConfiguration.java
+++ b/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/rpc/SofaRpcAutoConfiguration.java
@@ -16,6 +16,7 @@
  */
 package com.alipay.sofa.boot.autoconfigure.rpc;
 
+import com.alipay.sofa.boot.actuator.extension.ProviderConfigDelayRegisterCheckerSupport;
 import com.alipay.sofa.boot.autoconfigure.condition.ConditionalOnSwitch;
 import com.alipay.sofa.boot.autoconfigure.rpc.SofaRpcAutoConfiguration.RegistryConfigurationImportSelector;
 import com.alipay.sofa.boot.autoconfigure.runtime.SofaRuntimeAutoConfiguration;
@@ -72,12 +73,21 @@ public class SofaRpcAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    public ProviderConfigContainer providerConfigContainer(SofaBootRpcProperties sofaBootRpcProperties) {
+    public ProviderConfigDelayRegisterCheckerSupport providerConfigDelayRegisterCheckerSupport() {
+        return new ProviderConfigDelayRegisterCheckerSupport();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public ProviderConfigContainer providerConfigContainer(SofaBootRpcProperties sofaBootRpcProperties,
+                                                           ProviderConfigDelayRegisterCheckerSupport providerConfigDelayRegisterCheckerSupport) {
         ProviderConfigContainer providerConfigContainer = new ProviderConfigContainer();
         providerConfigContainer.setProviderRegisterWhiteList(sofaBootRpcProperties
             .getProviderRegisterWhiteList());
         providerConfigContainer.setProviderRegisterBlackList(sofaBootRpcProperties
             .getProviderRegisterBlackList());
+        providerConfigContainer
+            .setProviderConfigDelayRegister(providerConfigDelayRegisterCheckerSupport);
         return providerConfigContainer;
     }
 

--- a/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/rpc/SofaRpcAutoConfiguration.java
+++ b/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/rpc/SofaRpcAutoConfiguration.java
@@ -16,7 +16,7 @@
  */
 package com.alipay.sofa.boot.autoconfigure.rpc;
 
-import com.alipay.sofa.boot.actuator.extension.ProviderConfigDelayRegisterCheckerSupport;
+import com.alipay.sofa.boot.actuator.rpc.HealthCheckProviderConfigDelayRegisterChecker;
 import com.alipay.sofa.boot.autoconfigure.condition.ConditionalOnSwitch;
 import com.alipay.sofa.boot.autoconfigure.rpc.SofaRpcAutoConfiguration.RegistryConfigurationImportSelector;
 import com.alipay.sofa.boot.autoconfigure.runtime.SofaRuntimeAutoConfiguration;
@@ -56,6 +56,7 @@ import org.springframework.core.type.AnnotationMetadata;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * {@link EnableAutoConfiguration Auto-configuration} for sofa Rpc.
@@ -73,21 +74,18 @@ public class SofaRpcAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    public ProviderConfigDelayRegisterCheckerSupport providerConfigDelayRegisterCheckerSupport() {
-        return new ProviderConfigDelayRegisterCheckerSupport();
-    }
-
-    @Bean
-    @ConditionalOnMissingBean
     public ProviderConfigContainer providerConfigContainer(SofaBootRpcProperties sofaBootRpcProperties,
-                                                           ProviderConfigDelayRegisterCheckerSupport providerConfigDelayRegisterCheckerSupport) {
+                                                           ObjectProvider<HealthCheckProviderConfigDelayRegisterChecker> healthCheckProviderConfigDelayRegisterChecker) {
         ProviderConfigContainer providerConfigContainer = new ProviderConfigContainer();
         providerConfigContainer.setProviderRegisterWhiteList(sofaBootRpcProperties
             .getProviderRegisterWhiteList());
         providerConfigContainer.setProviderRegisterBlackList(sofaBootRpcProperties
             .getProviderRegisterBlackList());
         providerConfigContainer
-            .setProviderConfigDelayRegister(providerConfigDelayRegisterCheckerSupport);
+            .setProviderConfigDelayRegister(healthCheckProviderConfigDelayRegisterChecker.stream()
+                .collect(Collectors.toList()));
+        providerConfigContainer.setEnableDelayRegister(sofaBootRpcProperties
+            .getEnableDelayRegister());
         return providerConfigContainer;
     }
 

--- a/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/main/java/com/alipay/sofa/rpc/boot/container/ProviderConfigContainer.java
+++ b/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/main/java/com/alipay/sofa/rpc/boot/container/ProviderConfigContainer.java
@@ -146,17 +146,17 @@ public class ProviderConfigContainer {
     public void publishAllProviderConfig() {
         for (ProviderConfig providerConfig : getAllProviderConfig()) {
             int delay = providerConfig.getDelay();
-            // 没有配置延时加载则直接去注册中心注册服务
-            if (!enableDelayRegister && delay <= 0) {
-                doPublishProviderConfig(providerConfig);
-            } else {
+            if (enableDelayRegister && delay > 0) {
                 // 根据延时时间异步去注册中心注册服务
                 if (scheduledExecutorService == null) {
-                    scheduledExecutorService = new SofaScheduledThreadPoolExecutor(1, "async-register-bean",
+                    scheduledExecutorService = new SofaScheduledThreadPoolExecutor(1, "rpc-provider-delay-register",
                             SofaBootConstants.SOFA_BOOT_SPACE_NAME);
                 }
                 scheduledExecutorService.schedule(() -> doDelayPublishProviderConfig(providerConfig,
                         providerConfigDelayRegisterCheckerList), delay, TimeUnit.MILLISECONDS);
+            } else {
+                // 没有配置延时加载则直接去注册中心注册服务
+                doPublishProviderConfig(providerConfig);
             }
         }
     }

--- a/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/main/java/com/alipay/sofa/rpc/boot/container/ProviderConfigDelayRegisterChecker.java
+++ b/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/main/java/com/alipay/sofa/rpc/boot/container/ProviderConfigDelayRegisterChecker.java
@@ -14,9 +14,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.alipay.sofa.rpc.boot.extension;
+package com.alipay.sofa.rpc.boot.container;
 
+/**
+ * 延时发布后注册服务到注册中心的健康检查
+ */
 public interface ProviderConfigDelayRegisterChecker {
 
-    boolean isDelayRegisterHealthCheck();
+    /**
+     * 是否允许注册服务到注册中心
+     *
+     * @return
+     */
+    boolean allowRegister();
 }

--- a/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/main/java/com/alipay/sofa/rpc/boot/extension/ProviderConfigDelayRegisterChecker.java
+++ b/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/main/java/com/alipay/sofa/rpc/boot/extension/ProviderConfigDelayRegisterChecker.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.rpc.boot.extension;
+
+public interface ProviderConfigDelayRegisterChecker {
+
+    boolean isDelayRegisterHealthCheck();
+}

--- a/sofa-boot-tests/sofa-boot-smoke-tests/sofa-boot-smoke-tests-rpc/src/main/java/com/alipay/sofa/smoke/tests/rpc/boot/bean/delayregister/DelayRegisterService.java
+++ b/sofa-boot-tests/sofa-boot-smoke-tests/sofa-boot-smoke-tests-rpc/src/main/java/com/alipay/sofa/smoke/tests/rpc/boot/bean/delayregister/DelayRegisterService.java
@@ -14,17 +14,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.alipay.sofa.rpc.boot.container;
+package com.alipay.sofa.smoke.tests.rpc.boot.bean.delayregister;
 
 /**
- * 用于判断是否允许延迟服务发布至注册中心的扩展点
+ * @author chengming
+ * @version DelayRegisterService.java, v 0.1 2024年02月26日 3:37 PM chengming
  */
-public interface ProviderConfigDelayRegisterChecker {
+public interface DelayRegisterService {
 
-    /**
-     * 是否允许注册服务到注册中心
-     *
-     * @return
-     */
-    boolean allowRegister();
+    String sayHello(String string);
 }

--- a/sofa-boot-tests/sofa-boot-smoke-tests/sofa-boot-smoke-tests-rpc/src/main/java/com/alipay/sofa/smoke/tests/rpc/boot/bean/delayregister/DelayRegisterServiceImpl.java
+++ b/sofa-boot-tests/sofa-boot-smoke-tests/sofa-boot-smoke-tests-rpc/src/main/java/com/alipay/sofa/smoke/tests/rpc/boot/bean/delayregister/DelayRegisterServiceImpl.java
@@ -14,17 +14,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.alipay.sofa.rpc.boot.container;
+package com.alipay.sofa.smoke.tests.rpc.boot.bean.delayregister;
 
 /**
- * 用于判断是否允许延迟服务发布至注册中心的扩展点
+ * @author chengming
+ * @version DelayRegisterServiceImpl.java, v 0.1 2024年02月26日 3:39 PM chengming
  */
-public interface ProviderConfigDelayRegisterChecker {
+public class DelayRegisterServiceImpl implements DelayRegisterService {
 
-    /**
-     * 是否允许注册服务到注册中心
-     *
-     * @return
-     */
-    boolean allowRegister();
+    @Override
+    public String sayHello(String string) {
+        return string;
+    }
 }

--- a/sofa-boot-tests/sofa-boot-smoke-tests/sofa-boot-smoke-tests-rpc/src/main/resources/META-INF/sofa-rpc/rpc-config.json
+++ b/sofa-boot-tests/sofa-boot-smoke-tests/sofa-boot-smoke-tests-rpc/src/main/resources/META-INF/sofa-rpc/rpc-config.json
@@ -1,5 +1,6 @@
 {
   "default.proxy": "javassist",
   "rpc.config.order": 1000,
-  "consumer.address.wait": 1
+  "consumer.address.wait": 1,
+  "provider.delay": 5000
 }

--- a/sofa-boot-tests/sofa-boot-smoke-tests/sofa-boot-smoke-tests-rpc/src/main/resources/spring/test_only_delay_register.xml
+++ b/sofa-boot-tests/sofa-boot-smoke-tests/sofa-boot-smoke-tests-rpc/src/main/resources/spring/test_only_delay_register.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:sofa="http://sofastack.io/schema/sofaboot"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+            http://sofastack.io/schema/sofaboot   http://sofastack.io/schema/sofaboot.xsd">
+
+    <bean id="delayRegisterServiceImpl" class="com.alipay.sofa.smoke.tests.rpc.boot.bean.delayregister.DelayRegisterServiceImpl"/>
+    <sofa:service ref="delayRegisterServiceImpl" interface="com.alipay.sofa.smoke.tests.rpc.boot.bean.delayregister.DelayRegisterService">
+        <sofa:binding.bolt/>
+    </sofa:service>
+    <sofa:reference jvm-first="false" id="delayRegisterService" interface="com.alipay.sofa.smoke.tests.rpc.boot.bean.delayregister.DelayRegisterService">
+        <sofa:binding.bolt/>
+    </sofa:reference>
+
+</beans>

--- a/sofa-boot-tests/sofa-boot-smoke-tests/sofa-boot-smoke-tests-rpc/src/test/java/com/alipay/sofa/smoke/tests/rpc/delayregister/DelayRegisterTests.java
+++ b/sofa-boot-tests/sofa-boot-smoke-tests/sofa-boot-smoke-tests-rpc/src/test/java/com/alipay/sofa/smoke/tests/rpc/delayregister/DelayRegisterTests.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.smoke.tests.rpc.delayregister;
+
+import com.alipay.sofa.rpc.core.exception.SofaRouteException;
+import com.alipay.sofa.smoke.tests.rpc.boot.RpcSofaBootApplication;
+import com.alipay.sofa.smoke.tests.rpc.boot.bean.delayregister.DelayRegisterService;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.ImportResource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author chengming
+ * @version DelayRegisterTests.java, v 0.1 2024年02月26日 3:58 PM chengming
+ */
+@SpringBootTest(classes = RpcSofaBootApplication.class, properties = {
+                                                                      "sofa.boot.rpc.registry.address=zookeeper://127.0.0.1:2181",
+                                                                      "sofa.boot.rpc.enable-auto-publish=true",
+                                                                      "sofa.boot.rpc.enable-delay-register=true" })
+@Import(DelayRegisterTests.DelayRegisterConfiguration.class)
+public class DelayRegisterTests {
+
+    @Autowired
+    private DelayRegisterService delayRegisterService;
+
+    /**
+     * 延时五秒注册
+     */
+    @Test
+    public void testDelayRegister() throws InterruptedException {
+        // 首次发起调用、期望返回 RPC-020060001: Cannot get the service address of service
+        Assertions.assertThatThrownBy(() -> delayRegisterService.sayHello("hi")).isInstanceOf(SofaRouteException.class).
+                hasMessageContaining("Cannot get the service address of service [com.alipay.sofa.smoke.tests.rpc.boot.bean.delayregister.DelayRegisterService:1.0], please check the registry log.");
+        // 因为在 META-INF/sofa-rpc/rpc-config.json 配置了5s
+        Thread.sleep(5000);
+
+        // 等待5s之后可以正常发起调用
+        String hi = delayRegisterService.sayHello("hi");
+        assertThat(hi).isEqualTo("hi");
+    }
+
+    @Configuration
+    @ImportResource("/spring/test_only_delay_register.xml")
+    static class DelayRegisterConfiguration {
+
+    }
+}

--- a/sofa-boot-tests/sofa-boot-smoke-tests/sofa-boot-smoke-tests-rpc/src/test/java/com/alipay/sofa/smoke/tests/rpc/delayregister/DelayRegisterTests.java
+++ b/sofa-boot-tests/sofa-boot-smoke-tests/sofa-boot-smoke-tests-rpc/src/test/java/com/alipay/sofa/smoke/tests/rpc/delayregister/DelayRegisterTests.java
@@ -48,7 +48,7 @@ public class DelayRegisterTests {
      */
     @Test
     public void testDelayRegister() throws InterruptedException {
-        // 首次发起调用、期望返回 RPC-020060001: Cannot get the service address of service
+        // 首次发起调用、期望返回 RPC cannot find service
         Assertions.assertThatThrownBy(() -> delayRegisterService.sayHello("hi")).isInstanceOf(SofaRouteException.class).
                 hasMessageContaining("Cannot get the service address of service [com.alipay.sofa.smoke.tests.rpc.boot.bean.delayregister.DelayRegisterService:1.0], please check the registry log.");
         // 因为在 META-INF/sofa-rpc/rpc-config.json 配置了5s


### PR DESCRIPTION
# 方案
在`rpc-sofa-boot`里定义一个否允许延迟服务发布至注册中心的扩展点，然后在`sofa-boot-actuator`里判断应用的健康状态，通过后再继续注册到注册中心。

# 修复后验证
demo地址：https://github.com/wangchengming666/sofa-boot-delay-demo
需要在配置里加上这两行
```
sofa.boot.rpc.enable-auto-publish=true
sofa.boot.rpc.enable-delay-register=true
```

我的demo验证情况如下，我有一个接口配置了延时10s发布、然后应用启动后会2s循环调用一下，理论上前4~5次都会出现`Cannot get the service address of service`的异常，之后会正常调用，控制台日志打印如下

```
2024-02-23 14:50:39.740  INFO 66775 --- [           main] .b.s.StartupSpringApplicationRunListener : Started SOFABoot Demo in 2.556 seconds
com.alipay.sofa.rpc.core.exception.SofaRouteException: RPC-020060001: Cannot get the service address of service [com.example.sofabootprovider.HelloService:1.0], please check the registry log. 
	at com.alipay.sofa.rpc.client.AbstractCluster.noAvailableProviderException(AbstractCluster.java:502)
	at com.alipay.sofa.rpc.client.AbstractCluster.select(AbstractCluster.java:423)
	at com.alipay.sofa.rpc.client.FailoverCluster.doInvoke(FailoverCluster.java:67)
	at com.alipay.sofa.rpc.client.AbstractCluster.invoke(AbstractCluster.java:298)
	at com.alipay.sofa.rpc.client.ClientProxyInvoker.invoke(ClientProxyInvoker.java:83)
	at com.example.sofabootprovider.HelloService_proxy_0.sayHello(HelloService_proxy_0.java)
	at com.example.sofabootprovider.SofaBootProviderApplication.main(SofaBootProviderApplication.java:26)
com.alipay.sofa.rpc.core.exception.SofaRouteException: RPC-020060001: Cannot get the service address of service [com.example.sofabootprovider.HelloService:1.0], please check the registry log. 
	at com.alipay.sofa.rpc.client.AbstractCluster.noAvailableProviderException(AbstractCluster.java:502)
	at com.alipay.sofa.rpc.client.AbstractCluster.select(AbstractCluster.java:423)
	at com.alipay.sofa.rpc.client.FailoverCluster.doInvoke(FailoverCluster.java:67)
	at com.alipay.sofa.rpc.client.AbstractCluster.invoke(AbstractCluster.java:298)
	at com.alipay.sofa.rpc.client.ClientProxyInvoker.invoke(ClientProxyInvoker.java:83)
	at com.example.sofabootprovider.HelloService_proxy_0.sayHello(HelloService_proxy_0.java)
	at com.example.sofabootprovider.SofaBootProviderApplication.main(SofaBootProviderApplication.java:26)
com.alipay.sofa.rpc.core.exception.SofaRouteException: RPC-020060001: Cannot get the service address of service [com.example.sofabootprovider.HelloService:1.0], please check the registry log. 
	at com.alipay.sofa.rpc.client.AbstractCluster.noAvailableProviderException(AbstractCluster.java:502)
	at com.alipay.sofa.rpc.client.AbstractCluster.select(AbstractCluster.java:423)
	at com.alipay.sofa.rpc.client.FailoverCluster.doInvoke(FailoverCluster.java:67)
	at com.alipay.sofa.rpc.client.AbstractCluster.invoke(AbstractCluster.java:298)
	at com.alipay.sofa.rpc.client.ClientProxyInvoker.invoke(ClientProxyInvoker.java:83)
	at com.example.sofabootprovider.HelloService_proxy_0.sayHello(HelloService_proxy_0.java)
	at com.example.sofabootprovider.SofaBootProviderApplication.main(SofaBootProviderApplication.java:26)
com.alipay.sofa.rpc.core.exception.SofaRouteException: RPC-020060001: Cannot get the service address of service [com.example.sofabootprovider.HelloService:1.0], please check the registry log. 
	at com.alipay.sofa.rpc.client.AbstractCluster.noAvailableProviderException(AbstractCluster.java:502)
	at com.alipay.sofa.rpc.client.AbstractCluster.select(AbstractCluster.java:423)
	at com.alipay.sofa.rpc.client.FailoverCluster.doInvoke(FailoverCluster.java:67)
	at com.alipay.sofa.rpc.client.AbstractCluster.invoke(AbstractCluster.java:298)
	at com.alipay.sofa.rpc.client.ClientProxyInvoker.invoke(ClientProxyInvoker.java:83)
	at com.example.sofabootprovider.HelloService_proxy_0.sayHello(HelloService_proxy_0.java)
	at com.example.sofabootprovider.SofaBootProviderApplication.main(SofaBootProviderApplication.java:26)
2024-02-23T14:50:49.799+08:00  WARN 66775 --- [SOFABoot Demo] [           main] io.fury.config.FuryBuilder               : Class registration isn't forced, unknown classes can be deserialized. If the environment isn't secure, please enable class registration by `FuryBuilder#requireClassRegistration(true)` or configure ClassChecker by `ClassResolver#setClassChecker`
2024-02-23T14:50:49.850+08:00  INFO 66775 --- [SOFABoot Demo] [           main] io.fury.Fury                             : Created new fury io.fury.Fury@5c703860
hello world
hello world
hello world
hello world
hello world
hello world
hello world
```

