### PR TITLE
Support mac M1(osx-aarch_64) compile and test

### DIFF
--- a/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/pom.xml
+++ b/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/pom.xml
@@ -14,6 +14,7 @@
     <properties>
         <main.user.dir>${basedir}/../../..</main.user.dir>
         <sofa.rpc.compiler.version>0.0.3</sofa.rpc.compiler.version>
+        <protobuf.protoc.version>3.17.3</protobuf.protoc.version>
     </properties>
 
     <dependencies>
@@ -152,7 +153,7 @@
                 <artifactId>protobuf-maven-plugin</artifactId>
                 <version>0.5.1</version>
                 <configuration>
-                    <protocArtifact>com.google.protobuf:protoc:3.7.1:exe:${os.detected.classifier}</protocArtifact>
+                    <protocArtifact>com.google.protobuf:protoc:${protobuf.protoc.version}:exe:${os.detected.classifier}</protocArtifact>
                     <pluginId>grpc-java</pluginId>
                     <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
                     <outputDirectory>build/generated/source/proto/test/java</outputDirectory>

--- a/sofa-boot-tests/sofa-boot-smoke-tests/sofa-boot-smoke-tests-rpc/pom.xml
+++ b/sofa-boot-tests/sofa-boot-smoke-tests/sofa-boot-smoke-tests-rpc/pom.xml
@@ -32,6 +32,7 @@
     <properties>
         <main.user.dir>${basedir}/../../..</main.user.dir>
         <sofa.rpc.compiler.version>0.0.3</sofa.rpc.compiler.version>
+        <protobuf.protoc.version>3.17.3</protobuf.protoc.version>
     </properties>
 
     <dependencies>
@@ -115,7 +116,7 @@
                 <artifactId>protobuf-maven-plugin</artifactId>
                 <version>0.5.1</version>
                 <configuration>
-                    <protocArtifact>com.google.protobuf:protoc:3.7.1:exe:${os.detected.classifier}</protocArtifact>
+                    <protocArtifact>com.google.protobuf:protoc:${protobuf.protoc.version}:exe:${os.detected.classifier}</protocArtifact>
                     <pluginId>grpc-java</pluginId>
                     <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
                     <outputDirectory>build/generated/source/proto/test/java</outputDirectory>


### PR DESCRIPTION
protoc 3.7.1 don't support osx-aarch_64
https://repo1.maven.org/maven2/com/google/protobuf/protoc/3.7.1/

Minimum supported version is 3.17.3: 
https://repo1.maven.org/maven2/com/google/protobuf/protoc/3.17.3/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the `protobuf` library version to `3.17.3` to ensure compatibility and enhance performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->