### PR TITLE
Support mac M1(osx-aarch_64) compile and test

### DIFF
--- a/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/pom.xml
+++ b/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/pom.xml
@@ -16,6 +16,7 @@
         <main.user.dir>${basedir}/../../..</main.user.dir>
         <sofa.rpc.compiler.version>0.0.3</sofa.rpc.compiler.version>
         <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
+        <protobuf.protoc.version>3.17.3</protobuf.protoc.version>
     </properties>
 
     <dependencies>
@@ -193,7 +194,7 @@
                 <artifactId>protobuf-maven-plugin</artifactId>
                 <version>0.5.1</version>
                 <configuration>
-                    <protocArtifact>com.google.protobuf:protoc:3.7.1:exe:${os.detected.classifier}</protocArtifact>
+                    <protocArtifact>com.google.protobuf:protoc:${protobuf.protoc.version}:exe:${os.detected.classifier}</protocArtifact>
                     <pluginId>grpc-java</pluginId>
                     <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
                     <outputDirectory>build/generated/source/proto/test/java</outputDirectory>

--- a/sofa-boot-project/sofaboot-dependencies/pom.xml
+++ b/sofa-boot-project/sofaboot-dependencies/pom.xml
@@ -53,7 +53,7 @@
         <nacos.version>1.0.0</nacos.version>
         <swagger.version>2.0.0</swagger.version>
         <protoc.version>3.11.0</protoc.version>
-        <grpc.version>1.28.0</grpc.version>
+        <grpc.version>1.53.0</grpc.version>
         <grpc.common.protos.version>1.17.0</grpc.common.protos.version>
     </properties>
 


### PR DESCRIPTION
protoc 3.7.1 don't support osx-aarch_64
https://repo1.maven.org/maven2/com/google/protobuf/protoc/3.7.1/

Minimum supported version is 3.17.3:
https://repo1.maven.org/maven2/com/google/protobuf/protoc/3.17.3/

io.grpc:protoc-gen-grpc-java 1.28.0 don't support osx-aarch_64
https://repo.maven.apache.org/maven2/io/grpc/protoc-gen-grpc-java/1.28.0/

Minimum supported version is 1.42.3:
https://repo.maven.apache.org/maven2/io/grpc/protoc-gen-grpc-java/1.42.3/

