### PR TITLE
Fix readme for build status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## SOFABoot
 
-![build](https://github.com/sofastack/sofa-boot/workflows/build/badge.svg)
+![build](https://github.com/sofastack/sofa-boot/actions/workflows/maven.yml)
 [![Coverage Status](https://codecov.io/gh/sofastack/sofa-boot/branch/master/graph/badge.svg)](https://codecov.io/gh/sofastack/sofa-boot/branch/master)
 ![license](https://img.shields.io/badge/license-Apache--2.0-green.svg)
 [![Average time to resolve an issue](http://isitmaintained.com/badge/resolution/sofastack/sofa-boot.svg)](http://isitmaintained.com/project/sofastack/sofa-boot "Average time to resolve an issue")

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -1,6 +1,6 @@
 ## SOFABoot
 
-![build](https://github.com/sofastack/sofa-boot/workflows/build/badge.svg)
+![build](https://github.com/sofastack/sofa-boot/actions/workflows/maven.yml)
 [![Coverage Status](https://codecov.io/gh/sofastack/sofa-boot/branch/master/graph/badge.svg)](https://codecov.io/gh/sofastack/sofa-boot/branch/master)
 ![license](https://img.shields.io/badge/license-Apache--2.0-green.svg)
 [![Average time to resolve an issue](http://isitmaintained.com/badge/resolution/sofastack/sofa-boot.svg)](http://isitmaintained.com/project/sofastack/sofa-boot "Average time to resolve an issue")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated the build badge URL in the README to reflect the latest workflow path.
	- Updated the build badge URL in the `README_ZH.md` file for `SOFABoot` from a GitHub Actions workflow badge to a Maven badge.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->