### PR TITLE
Fix sofaruntime manager destroy whitout shutdown

### DIFF
--- a/sofa-boot-project/sofa-boot-core/ark-sofa-boot/src/main/java/com/alipay/sofa/boot/ark/SofaRuntimeContainer.java
+++ b/sofa-boot-project/sofa-boot-core/ark-sofa-boot/src/main/java/com/alipay/sofa/boot/ark/SofaRuntimeContainer.java
@@ -18,7 +18,6 @@ package com.alipay.sofa.boot.ark;
 
 import com.alipay.sofa.runtime.spi.component.SofaRuntimeManager;
 import org.springframework.beans.BeansException;
-import org.springframework.beans.factory.DisposableBean;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.util.Assert;
@@ -34,7 +33,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * @author huzijie
  * @since 2.5.0
  */
-public class SofaRuntimeContainer implements ApplicationContextAware, DisposableBean {
+public class SofaRuntimeContainer implements ApplicationContextAware {
 
     private static final Map<ClassLoader, ApplicationContext> APPLICATION_CONTEXT_MAP  = new ConcurrentHashMap<>();
 
@@ -104,10 +103,14 @@ public class SofaRuntimeContainer implements ApplicationContextAware, Disposable
         JVM_INVOKE_SERIALIZE_MAP.clear();
     }
 
-    @Override
-    public void destroy() {
+    public static void destroy(ClassLoader contextClassLoader) {
         APPLICATION_CONTEXT_MAP.remove(contextClassLoader);
-        SOFA_RUNTIME_MANAGER_MAP.remove(contextClassLoader);
+
+        SofaRuntimeManager sofaRuntimeManager = SOFA_RUNTIME_MANAGER_MAP.remove(contextClassLoader);
+        if (sofaRuntimeManager != null) {
+            sofaRuntimeManager.shutDownExternally();
+        }
+
         JVM_SERVICE_CACHE_MAP.remove(contextClassLoader);
         JVM_INVOKE_SERIALIZE_MAP.remove(contextClassLoader);
     }

--- a/sofa-boot-project/sofa-boot-core/ark-sofa-boot/src/main/java/com/alipay/sofa/boot/ark/handler/SofaBizUninstallEventHandler.java
+++ b/sofa-boot-project/sofa-boot-core/ark-sofa-boot/src/main/java/com/alipay/sofa/boot/ark/handler/SofaBizUninstallEventHandler.java
@@ -42,13 +42,8 @@ public class SofaBizUninstallEventHandler implements EventHandler<BeforeBizStopE
         // Remove dynamic JVM service cache
         DynamicJvmServiceProxyFinder.getInstance().afterBizUninstall(biz);
 
-        SofaRuntimeManager sofaRuntimeManager = SofaRuntimeContainer.getSofaRuntimeManager(biz
-            .getBizClassLoader());
+        SofaRuntimeContainer.destroy(biz.getBizClassLoader());
 
-        if (sofaRuntimeManager == null) {
-            throw new IllegalStateException("No SofaRuntimeManager match classLoader");
-        }
-        sofaRuntimeManager.shutDownExternally();
     }
 
     @Override

--- a/sofa-boot-project/sofa-boot-core/ark-sofa-boot/src/test/java/com/alipay/sofa/boot/ark/SofaRuntimeContainerTests.java
+++ b/sofa-boot-project/sofa-boot-core/ark-sofa-boot/src/test/java/com/alipay/sofa/boot/ark/SofaRuntimeContainerTests.java
@@ -93,7 +93,7 @@ public class SofaRuntimeContainerTests {
 
         assertThat(SofaRuntimeContainer.getApplicationContext(classLoaderA)).isEqualTo(
             genericApplicationContext);
-        sofaRuntimeContainer.destroy();
+        sofaRuntimeContainer.destroy(classLoaderA);
         assertThat(SofaRuntimeContainer.getApplicationContext(classLoaderA)).isNull();
     }
 

--- a/sofa-boot-project/sofa-boot-core/ark-sofa-boot/src/test/java/com/alipay/sofa/boot/ark/handler/SofaBizUninstallEventHandlerTests.java
+++ b/sofa-boot-project/sofa-boot-core/ark-sofa-boot/src/test/java/com/alipay/sofa/boot/ark/handler/SofaBizUninstallEventHandlerTests.java
@@ -27,7 +27,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.support.GenericApplicationContext;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -48,14 +47,6 @@ public class SofaBizUninstallEventHandlerTests {
     @BeforeEach
     public void clear() {
         SofaRuntimeContainer.clear();
-    }
-
-    @Test
-    public void noSofaRuntimeManager() {
-        MockBiz mockBiz = new MockBiz();
-        assertThatThrownBy(() -> sofaBizUninstallEventHandler.handleEvent(new BeforeBizStopEvent(mockBiz)))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessage("No SofaRuntimeManager match classLoader");
     }
 
     @Test


### PR DESCRIPTION
see https://github.com/sofastack/sofa-boot/issues/1321

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
  - Improved shutdown handling for `SofaRuntimeManager` to ensure it is properly shut down before removal.
  - Enhanced business artifact uninstallation process to prevent errors by checking if `sofaRuntimeManager` is not null before shutting it down.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->