### PR TITLE
Fix threadpool monitor when using virtual thread

### DIFF
--- a/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/main/java/com/alipay/sofa/rpc/boot/container/ServerConfigContainer.java
+++ b/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/main/java/com/alipay/sofa/rpc/boot/container/ServerConfigContainer.java
@@ -40,6 +40,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ThreadPoolExecutor;
 
 /**
@@ -275,9 +276,14 @@ public class ServerConfigContainer {
                 } else {
                     customThreadPoolMonitor.setPoolName(pool.getThreadPoolName());
                 }
-                customThreadPoolMonitor.setThreadPoolExecutor(pool.getExecutor());
-                customThreadPoolMonitor.start();
-                poolNames.add(pool.getThreadPoolName());
+
+                Executor tmp = pool.getUserExecutor();
+                if (tmp instanceof ThreadPoolExecutor) {
+                    customThreadPoolMonitor.setThreadPoolExecutor((ThreadPoolExecutor) pool
+                        .getUserExecutor());
+                    customThreadPoolMonitor.start();
+                    poolNames.add(pool.getThreadPoolName());
+                }
             }
         }
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced type safety by ensuring only valid `ThreadPoolExecutor` instances are set in the custom thread pool monitor, reducing the risk of runtime errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->