### PR TITLE
Update pom.xml

### DIFF
--- a/sofa-boot-project/sofaboot-dependencies/pom.xml
+++ b/sofa-boot-project/sofaboot-dependencies/pom.xml
@@ -26,11 +26,11 @@
         <!--core-->
         <sofa.registry.version>5.4.2</sofa.registry.version>
         <tracer.core.version>3.1.3</tracer.core.version>
-        <rpc.core.version>5.8.3</rpc.core.version>
+        <rpc.core.version>5.13.2</rpc.core.version>
 
         <!--2rd lib dependency-->
-        <sofa.common.tools.version>1.3.11</sofa.common.tools.version>
-        <sofa.bolt.version>1.5.10</sofa.bolt.version>
+        <sofa.common.tools.version>1.4.0</sofa.common.tools.version>
+        <sofa.bolt.version>1.6.10</sofa.bolt.version>
         <sofa.hessian.version>3.5.5</sofa.hessian.version>
 
         <!--3rd lib dependency-->


### PR DESCRIPTION
fix 针对 上游 sofa-rpc-all 清理 Lookout sofastack/sofa-rpc#1447 修复类缺失问题 关联 https://github.com/sofastack/sofa-boot/pull/1347