### PR TITLE
fix 并行调用多例Bean时 annotationWrapper 导致的线程安全问题

### DIFF
--- a/sofa-boot-project/sofa-boot-core/runtime-sofa-boot/src/main/java/com/alipay/sofa/runtime/spring/ReferenceAnnotationBeanPostProcessor.java
+++ b/sofa-boot-project/sofa-boot-core/runtime-sofa-boot/src/main/java/com/alipay/sofa/runtime/spring/ReferenceAnnotationBeanPostProcessor.java
@@ -193,7 +193,7 @@ public class ReferenceAnnotationBeanPostProcessor implements BeanPostProcessor,
 
     private AnnotationWrapper<SofaReference> createAnnotationWrapper() {
         return AnnotationWrapper.create(SofaReference.class)
-                .withEnvironment(this.applicationContext.getEnvironment())
-                .withBinder(DefaultPlaceHolderBinder.INSTANCE);
+            .withEnvironment(this.applicationContext.getEnvironment())
+            .withBinder(DefaultPlaceHolderBinder.INSTANCE);
     }
 }

--- a/sofa-boot-project/sofa-boot-core/runtime-sofa-boot/src/main/java/com/alipay/sofa/runtime/spring/ReferenceAnnotationBeanPostProcessor.java
+++ b/sofa-boot-project/sofa-boot-core/runtime-sofa-boot/src/main/java/com/alipay/sofa/runtime/spring/ReferenceAnnotationBeanPostProcessor.java
@@ -56,18 +56,18 @@ import java.lang.reflect.Modifier;
 public class ReferenceAnnotationBeanPostProcessor implements BeanPostProcessor,
                                                  ApplicationContextAware, PriorityOrdered {
 
-    private static final Logger              LOGGER = SofaBootLoggerFactory
-                                                        .getLogger(ReferenceAnnotationBeanPostProcessor.class);
+    private static final Logger                                 LOGGER            = SofaBootLoggerFactory
+                                                                                      .getLogger(ReferenceAnnotationBeanPostProcessor.class);
 
-    private final SofaRuntimeContext         sofaRuntimeContext;
+    private final SofaRuntimeContext                            sofaRuntimeContext;
 
-    private final BindingAdapterFactory      bindingAdapterFactory;
+    private final BindingAdapterFactory                         bindingAdapterFactory;
 
-    private final BindingConverterFactory    bindingConverterFactory;
+    private final BindingConverterFactory                       bindingConverterFactory;
 
-    private ApplicationContext               applicationContext;
+    private ApplicationContext                                  applicationContext;
 
-    private AnnotationWrapper<SofaReference> annotationWrapper;
+    private final ThreadLocal<AnnotationWrapper<SofaReference>> annotationWrapper = new ThreadLocal<>();
 
     /**
      * To construct a ReferenceAnnotationBeanPostProcessor via a Spring Bean
@@ -97,7 +97,12 @@ public class ReferenceAnnotationBeanPostProcessor implements BeanPostProcessor,
                 return;
             }
 
-            sofaReferenceAnnotation = annotationWrapper.wrap(sofaReferenceAnnotation);
+            if (annotationWrapper.get() == null) {
+                annotationWrapper.set(AnnotationWrapper.create(SofaReference.class)
+                        .withEnvironment(applicationContext.getEnvironment())
+                        .withBinder(DefaultPlaceHolderBinder.INSTANCE));
+            }
+            sofaReferenceAnnotation = annotationWrapper.get().wrap(sofaReferenceAnnotation);
 
             Class<?> interfaceType = sofaReferenceAnnotation.interfaceType();
             if (interfaceType.equals(void.class)) {
@@ -130,7 +135,12 @@ public class ReferenceAnnotationBeanPostProcessor implements BeanPostProcessor,
                 return;
             }
 
-            sofaReferenceAnnotation = annotationWrapper.wrap(sofaReferenceAnnotation);
+            if (annotationWrapper.get() == null) {
+                annotationWrapper.set(AnnotationWrapper.create(SofaReference.class)
+                        .withEnvironment(applicationContext.getEnvironment())
+                        .withBinder(DefaultPlaceHolderBinder.INSTANCE));
+            }
+            sofaReferenceAnnotation = annotationWrapper.get().wrap(sofaReferenceAnnotation);
 
             Class<?> interfaceType = sofaReferenceAnnotation.interfaceType();
             if (interfaceType.equals(void.class)) {
@@ -182,8 +192,8 @@ public class ReferenceAnnotationBeanPostProcessor implements BeanPostProcessor,
     @Override
     public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
         this.applicationContext = applicationContext;
-        this.annotationWrapper = AnnotationWrapper.create(SofaReference.class)
+        this.annotationWrapper.set(AnnotationWrapper.create(SofaReference.class)
             .withEnvironment(applicationContext.getEnvironment())
-            .withBinder(DefaultPlaceHolderBinder.INSTANCE);
+            .withBinder(DefaultPlaceHolderBinder.INSTANCE));
     }
 }

--- a/sofa-boot-project/sofa-boot-core/runtime-sofa-boot/src/main/java/com/alipay/sofa/runtime/spring/ReferenceAnnotationBeanPostProcessor.java
+++ b/sofa-boot-project/sofa-boot-core/runtime-sofa-boot/src/main/java/com/alipay/sofa/runtime/spring/ReferenceAnnotationBeanPostProcessor.java
@@ -98,9 +98,7 @@ public class ReferenceAnnotationBeanPostProcessor implements BeanPostProcessor,
             }
 
             if (annotationWrapper.get() == null) {
-                annotationWrapper.set(AnnotationWrapper.create(SofaReference.class)
-                        .withEnvironment(applicationContext.getEnvironment())
-                        .withBinder(DefaultPlaceHolderBinder.INSTANCE));
+                annotationWrapper.set(createAnnotationWrapper());
             }
             sofaReferenceAnnotation = annotationWrapper.get().wrap(sofaReferenceAnnotation);
 
@@ -136,9 +134,7 @@ public class ReferenceAnnotationBeanPostProcessor implements BeanPostProcessor,
             }
 
             if (annotationWrapper.get() == null) {
-                annotationWrapper.set(AnnotationWrapper.create(SofaReference.class)
-                        .withEnvironment(applicationContext.getEnvironment())
-                        .withBinder(DefaultPlaceHolderBinder.INSTANCE));
+                annotationWrapper.set(createAnnotationWrapper());
             }
             sofaReferenceAnnotation = annotationWrapper.get().wrap(sofaReferenceAnnotation);
 
@@ -192,8 +188,12 @@ public class ReferenceAnnotationBeanPostProcessor implements BeanPostProcessor,
     @Override
     public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
         this.applicationContext = applicationContext;
-        this.annotationWrapper.set(AnnotationWrapper.create(SofaReference.class)
-            .withEnvironment(applicationContext.getEnvironment())
-            .withBinder(DefaultPlaceHolderBinder.INSTANCE));
+        this.annotationWrapper.set(createAnnotationWrapper());
+    }
+
+    private AnnotationWrapper<SofaReference> createAnnotationWrapper() {
+        return AnnotationWrapper.create(SofaReference.class)
+                .withEnvironment(this.applicationContext.getEnvironment())
+                .withBinder(DefaultPlaceHolderBinder.INSTANCE);
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced thread safety for the `annotationWrapper` variable, allowing separate instances for each thread.

- **Bug Fixes**
	- Improved initialization logic for `annotationWrapper` to ensure thread-specific instances are maintained.

- **Style**
	- Adjusted formatting of logger and variable declarations for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->