### PR TITLE
Upgrade rpc all version to  5.13.2

### DIFF
--- a/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/rpc/SofaRpcAutoConfiguration.java
+++ b/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/rpc/SofaRpcAutoConfiguration.java
@@ -271,11 +271,9 @@ public class SofaRpcAutoConfiguration {
                                                              ObjectProvider<FaultToleranceConfigurator> faultToleranceConfigurator,
                                                              ServerConfigContainer serverConfigContainer,
                                                              RegistryConfigContainer registryConfigContainer) {
-        SofaBootRpcStartListener rpcStartListener = new SofaBootRpcStartListener(
-            providerConfigContainer, faultToleranceConfigurator.getIfUnique(),
-            serverConfigContainer, registryConfigContainer);
-        rpcStartListener.setLookoutCollectDisable(sofaBootRpcProperties.getLookoutCollectDisable());
-        return rpcStartListener;
+        return new SofaBootRpcStartListener(providerConfigContainer,
+            faultToleranceConfigurator.getIfUnique(), serverConfigContainer,
+            registryConfigContainer);
     }
 
     @Bean

--- a/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/main/java/com/alipay/sofa/rpc/boot/context/SofaBootRpcStartListener.java
+++ b/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/main/java/com/alipay/sofa/rpc/boot/context/SofaBootRpcStartListener.java
@@ -16,14 +16,12 @@
  */
 package com.alipay.sofa.rpc.boot.context;
 
-import com.alipay.sofa.rpc.boot.common.SofaBootRpcParserUtil;
 import com.alipay.sofa.rpc.boot.config.FaultToleranceConfigurator;
 import com.alipay.sofa.rpc.boot.container.ProviderConfigContainer;
 import com.alipay.sofa.rpc.boot.container.RegistryConfigContainer;
 import com.alipay.sofa.rpc.boot.container.ServerConfigContainer;
 import com.alipay.sofa.rpc.boot.context.event.SofaBootRpcStartEvent;
 import com.alipay.sofa.rpc.config.ProviderConfig;
-import com.alipay.sofa.rpc.event.LookoutSubscriber;
 import org.springframework.context.ApplicationListener;
 import org.springframework.util.CollectionUtils;
 
@@ -46,8 +44,6 @@ public class SofaBootRpcStartListener implements ApplicationListener<SofaBootRpc
 
     protected final RegistryConfigContainer    registryConfigContainer;
 
-    private String                             lookoutCollectDisable;
-
     public SofaBootRpcStartListener(ProviderConfigContainer providerConfigContainer,
                                     FaultToleranceConfigurator faultToleranceConfigurator,
                                     ServerConfigContainer serverConfigContainer,
@@ -60,8 +56,6 @@ public class SofaBootRpcStartListener implements ApplicationListener<SofaBootRpc
 
     @Override
     public void onApplicationEvent(SofaBootRpcStartEvent event) {
-        //choose disable metrics lookout
-        disableLookout();
 
         //extra info
         processExtra(event);
@@ -90,17 +84,5 @@ public class SofaBootRpcStartListener implements ApplicationListener<SofaBootRpc
 
     protected void processExtra(SofaBootRpcStartEvent event) {
 
-    }
-
-    protected void disableLookout() {
-        Boolean disable = SofaBootRpcParserUtil.parseBoolean(lookoutCollectDisable);
-
-        if (disable != null) {
-            LookoutSubscriber.setLookoutCollectDisable(disable);
-        }
-    }
-
-    public void setLookoutCollectDisable(String lookoutCollectDisable) {
-        this.lookoutCollectDisable = lookoutCollectDisable;
     }
 }

--- a/sofa-boot-project/sofaboot-dependencies/pom.xml
+++ b/sofa-boot-project/sofaboot-dependencies/pom.xml
@@ -24,7 +24,7 @@
         <!-- sofa stack lib-->
         <sofa.registry.version>6.1.8</sofa.registry.version>
         <tracer.core.version>4.0.1</tracer.core.version>
-        <rpc.core.version>5.13.0</rpc.core.version>
+        <rpc.core.version>5.13.2</rpc.core.version>
         <sofa.common.tools.version>2.1.1</sofa.common.tools.version>
         <sofa.bolt.version>1.6.10</sofa.bolt.version>
         <sofa.hessian.version>3.5.5</sofa.hessian.version>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated the version of the `rpc.core` dependency to 5.13.2.
- **Refactor**
	- Simplified the implementation of the `sofaBootRpcStartListener` method in the `SofaRpcAutoConfiguration` class.
	- Removed unnecessary handling of the `lookoutCollectDisable` property in the `SofaBootRpcStartListener` class, including associated methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->