### PR TITLE
[AI-8th] chore: upgrade Spring Boot from 3.5.6 to 3.5.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.6</version>
+        <version>3.5.12</version>
     </parent>
 
     <groupId>com.alipay.sofa</groupId>
@@ -37,7 +37,7 @@
     <properties>
         <revision>4.6.0</revision>
         <sofa.boot.version>${revision}</sofa.boot.version>
-        <spring.boot.version>3.5.6</spring.boot.version>
+        <spring.boot.version>3.5.12</spring.boot.version>
         <!--project-->
         <java.version>17</java.version>
         <project.encoding>UTF-8</project.encoding>

--- a/sofa-boot-project/sofa-boot-tools/sofa-boot-gradle-plugin/pom.xml
+++ b/sofa-boot-project/sofa-boot-tools/sofa-boot-gradle-plugin/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-gradle-plugin</artifactId>
-            <version>3.5.6</version>
+            <version>3.5.12</version>
         </dependency>
         <dependency>
             <groupId>io.spring.gradle</groupId>


### PR DESCRIPTION
## Summary

Upgrade Spring Boot version from 3.5.6 to 3.5.12 (patch release).

Closes #1400

## Changes

- Update parent `spring-boot-starter-parent` version to 3.5.12
- Update `spring.boot.version` property to 3.5.12
- Update `spring-boot-gradle-plugin` dependency to 3.5.12

## Files Modified

| File | Change |
|------|--------|
| `pom.xml` (root) | parent version & spring.boot.version property |
| `sofa-boot-project/sofa-boot-tools/sofa-boot-gradle-plugin/pom.xml` | spring-boot-gradle-plugin version |

## Testing

- ✅ All 35 core modules: BUILD SUCCESS
- ✅ Gradle Plugin tests: BUILD SUCCESSFUL
- ⚠️ `sofa-boot-smoke-tests-rpc`: 42 Errors (local env issue - no ZooKeeper service, same as baseline before upgrade)
- ⚠️ `sofa-boot-smoke-tests-ark`: 1 Failure (local env issue - no ARK container, same as baseline before upgrade)

All failures are pre-existing local environment issues unrelated to the Spring Boot version upgrade.

## AI 协作记录

- **使用的 AI 工具**：Aone Copilot（基于 Claude 模型）
- **关键 Prompt**：用户提供了 SOFABoot 仓库的 issue #1400 链接，要求分析升级方案并将 Spring Boot 从 3.5.6 升级到 3.5.12。用户建议采用稳妥方案：先执行当前版本全量测试建立基线，升级后再进行回归测试验证。
- **AI 主要贡献**：
  - 分析 issue 内容，确认升级为 patch 版本无破坏性变更
  - 定位需要修改的 3 处 pom.xml 文件及具体行号
  - 执行升级前基线测试和升级后回归测试
  - 诊断 Gradle Plugin 模块测试失败的根因（本地 Gradle 环境缺失，非版本升级问题）
  - 完成 fork、commit、push、创建 PR 全流程
- **人工验证步骤**：
  - 确认升级方案（先基线测试 → 执行升级 → 回归测试）
  - 安装本地 Gradle 环境以解决 Gradle Plugin 测试问题
  - 审核 PR 内容和提交信息
- **遇到的问题**：
  - Gradle Plugin 模块测试因本地未安装 Gradle 且 Gradle Wrapper 下载 Gradle 9.1.0 超时而失败，AI 诊断出根因后，由用户手动安装 Gradle 解决
  - RPC/ARK smoke tests 因本地缺少 ZooKeeper/ARK 容器而失败，AI 通过基线对比确认这些失败与版本升级无关