### PR TITLE
[AI-8th] build: upgrade Spring Boot to 3.5.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.6</version>
+        <version>3.5.12</version>
     </parent>
 
     <groupId>com.alipay.sofa</groupId>
@@ -37,7 +37,7 @@
     <properties>
         <revision>4.6.0</revision>
         <sofa.boot.version>${revision}</sofa.boot.version>
-        <spring.boot.version>3.5.6</spring.boot.version>
+        <spring.boot.version>3.5.12</spring.boot.version>
         <!--project-->
         <java.version>17</java.version>
         <project.encoding>UTF-8</project.encoding>

--- a/sofa-boot-project/sofa-boot-tools/sofa-boot-gradle-plugin/build.gradle
+++ b/sofa-boot-project/sofa-boot-tools/sofa-boot-gradle-plugin/build.gradle
@@ -15,8 +15,8 @@ repositories {
 dependencies {
     implementation localGroovy()
     implementation gradleApi()
-    implementation 'org.springframework.boot:spring-boot-gradle-plugin:3.5.6'
-    implementation 'org.springframework.boot:spring-boot-loader-tools:3.5.6'
+    implementation 'org.springframework.boot:spring-boot-gradle-plugin:3.5.12'
+    implementation 'org.springframework.boot:spring-boot-loader-tools:3.5.12'
     implementation 'io.spring.gradle:dependency-management-plugin:1.1.7'
     implementation "org.apache.commons:commons-compress:1.19"
     implementation "org.springframework:spring-core:6.2.11"

--- a/sofa-boot-project/sofa-boot-tools/sofa-boot-gradle-plugin/pom.xml
+++ b/sofa-boot-project/sofa-boot-tools/sofa-boot-gradle-plugin/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-gradle-plugin</artifactId>
-            <version>3.5.6</version>
+            <version>3.5.12</version>
         </dependency>
         <dependency>
             <groupId>io.spring.gradle</groupId>


### PR DESCRIPTION
Upgrade Spring Boot from 3.5.6 to 3.5.12 to get security fixes,
bug fixes, and dependency upgrades.

Changes:
- pom.xml: Update spring-boot-starter-parent version to 3.5.12
- pom.xml: Update spring.boot.version property to 3.5.12
- sofa-boot-gradle-plugin/pom.xml: Update spring-boot-gradle-plugin version
- sofa-boot-gradle-plugin/build.gradle: Update spring-boot-gradle-plugin
  and spring-boot-loader-tools to 3.5.12

AI agent: JervyClaw (PR Challenge)
