### PR TITLE
[AI-8th] perf: add reflection cache

### DIFF
--- a/sofa-boot-project/sofa-boot-actuator-autoconfigure/src/main/java/com/alipay/sofa/boot/actuator/autoconfigure/health/ReadinessAutoConfiguration.java
+++ b/sofa-boot-project/sofa-boot-actuator-autoconfigure/src/main/java/com/alipay/sofa/boot/actuator/autoconfigure/health/ReadinessAutoConfiguration.java
@@ -30,6 +30,7 @@ import com.alipay.sofa.common.thread.NamedThreadFactory;
 import com.alipay.sofa.common.thread.SofaThreadPoolExecutor;
 import com.alipay.sofa.common.thread.virtual.SofaVirtualThreadFactory;
 import org.slf4j.Logger;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
@@ -99,10 +100,10 @@ public class ReadinessAutoConfiguration {
     @ConditionalOnMissingBean
     public HealthIndicatorProcessor healthIndicatorProcessor(HealthProperties healthCheckProperties,
                                                              ExecutorService readinessHealthCheckExecutor,
-                                                             ReflectionCache reflectionCache) {
+                                                             ObjectProvider<ReflectionCache> reflectionCacheProvider) {
         HealthIndicatorProcessor healthIndicatorProcessor = new HealthIndicatorProcessor();
         healthIndicatorProcessor.setHealthCheckExecutor(readinessHealthCheckExecutor);
-        healthIndicatorProcessor.setReflectionCache(reflectionCache);
+        reflectionCacheProvider.ifAvailable(healthIndicatorProcessor::setReflectionCache);
         healthIndicatorProcessor.initExcludedIndicators(healthCheckProperties
             .getExcludedIndicators());
         healthIndicatorProcessor.setParallelCheck(healthCheckProperties.isParallelCheck());

--- a/sofa-boot-project/sofa-boot-actuator-autoconfigure/src/main/java/com/alipay/sofa/boot/actuator/autoconfigure/health/ReadinessAutoConfiguration.java
+++ b/sofa-boot-project/sofa-boot-actuator-autoconfigure/src/main/java/com/alipay/sofa/boot/actuator/autoconfigure/health/ReadinessAutoConfiguration.java
@@ -25,6 +25,7 @@ import com.alipay.sofa.boot.autoconfigure.condition.OnVirtualThreadStartupAvaila
 import com.alipay.sofa.boot.autoconfigure.condition.OnVirtualThreadStartupDisableCondition;
 import com.alipay.sofa.boot.constant.SofaBootConstants;
 import com.alipay.sofa.boot.log.SofaBootLoggerFactory;
+import com.alipay.sofa.boot.reflection.ReflectionCache;
 import com.alipay.sofa.common.thread.NamedThreadFactory;
 import com.alipay.sofa.common.thread.SofaThreadPoolExecutor;
 import com.alipay.sofa.common.thread.virtual.SofaVirtualThreadFactory;
@@ -97,9 +98,11 @@ public class ReadinessAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean
     public HealthIndicatorProcessor healthIndicatorProcessor(HealthProperties healthCheckProperties,
-                                                             ExecutorService readinessHealthCheckExecutor) {
+                                                             ExecutorService readinessHealthCheckExecutor,
+                                                             ReflectionCache reflectionCache) {
         HealthIndicatorProcessor healthIndicatorProcessor = new HealthIndicatorProcessor();
         healthIndicatorProcessor.setHealthCheckExecutor(readinessHealthCheckExecutor);
+        healthIndicatorProcessor.setReflectionCache(reflectionCache);
         healthIndicatorProcessor.initExcludedIndicators(healthCheckProperties
             .getExcludedIndicators());
         healthIndicatorProcessor.setParallelCheck(healthCheckProperties.isParallelCheck());

--- a/sofa-boot-project/sofa-boot-actuator-autoconfigure/src/main/java/com/alipay/sofa/boot/actuator/autoconfigure/reflection/ReflectionCacheEndpointAutoConfiguration.java
+++ b/sofa-boot-project/sofa-boot-actuator-autoconfigure/src/main/java/com/alipay/sofa/boot/actuator/autoconfigure/reflection/ReflectionCacheEndpointAutoConfiguration.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.boot.actuator.autoconfigure.reflection;
+
+import com.alipay.sofa.boot.actuator.reflection.ReflectionCacheEndpoint;
+import com.alipay.sofa.boot.autoconfigure.reflection.ReflectionCacheAutoConfiguration;
+import com.alipay.sofa.boot.reflection.ReflectionCache;
+import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * Configures {@link ReflectionCacheEndpoint}.
+ *
+ * @author xiaosiyuan
+ * @since 4.5.0
+ */
+@AutoConfiguration(after = ReflectionCacheAutoConfiguration.class)
+@ConditionalOnBean(ReflectionCache.class)
+@ConditionalOnAvailableEndpoint(endpoint = ReflectionCacheEndpoint.class)
+public class ReflectionCacheEndpointAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean
+    public ReflectionCacheEndpoint reflectionCacheEndpoint(ReflectionCache reflectionCache) {
+        return new ReflectionCacheEndpoint(reflectionCache);
+    }
+}

--- a/sofa-boot-project/sofa-boot-actuator-autoconfigure/src/main/java/com/alipay/sofa/boot/actuator/autoconfigure/reflection/ReflectionCacheEndpointAutoConfiguration.java
+++ b/sofa-boot-project/sofa-boot-actuator-autoconfigure/src/main/java/com/alipay/sofa/boot/actuator/autoconfigure/reflection/ReflectionCacheEndpointAutoConfiguration.java
@@ -29,7 +29,6 @@ import org.springframework.context.annotation.Bean;
  * Configures {@link ReflectionCacheEndpoint}.
  *
  * @author xiaosiyuan
- * @since 4.5.0
  */
 @AutoConfiguration(after = ReflectionCacheAutoConfiguration.class)
 @ConditionalOnBean(ReflectionCache.class)

--- a/sofa-boot-project/sofa-boot-actuator-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/sofa-boot-project/sofa-boot-actuator-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,5 +1,6 @@
 com.alipay.sofa.boot.actuator.autoconfigure.beans.IsleBeansEndpointAutoConfiguration
 com.alipay.sofa.boot.actuator.autoconfigure.components.ComponentsEndpointAutoConfiguration
+com.alipay.sofa.boot.actuator.autoconfigure.reflection.ReflectionCacheEndpointAutoConfiguration
 com.alipay.sofa.boot.actuator.autoconfigure.health.ReadinessAutoConfiguration
 com.alipay.sofa.boot.actuator.autoconfigure.health.ReadinessIsleAutoConfiguration
 com.alipay.sofa.boot.actuator.autoconfigure.health.ReadinessEndpointAutoConfiguration

--- a/sofa-boot-project/sofa-boot-actuator-autoconfigure/src/test/java/com/alipay/sofa/boot/actuator/autoconfigure/health/ReadinessAutoConfigurationTests.java
+++ b/sofa-boot-project/sofa-boot-actuator-autoconfigure/src/test/java/com/alipay/sofa/boot/actuator/autoconfigure/health/ReadinessAutoConfigurationTests.java
@@ -26,6 +26,7 @@ import com.alipay.sofa.boot.autoconfigure.reflection.ReflectionCacheAutoConfigur
 import com.alipay.sofa.boot.autoconfigure.isle.SofaModuleAutoConfiguration;
 import com.alipay.sofa.boot.autoconfigure.runtime.SofaRuntimeAutoConfiguration;
 import com.alipay.sofa.boot.isle.ApplicationRuntimeModel;
+import com.alipay.sofa.boot.reflection.ReflectionCache;
 import com.alipay.sofa.runtime.spi.component.SofaRuntimeContext;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnJre;
@@ -59,6 +60,20 @@ public class ReadinessAutoConfigurationTests {
     void runShouldHaveReadinessBeans() {
         this.contextRunner
                 .run((context) -> assertThat(context)
+                        .hasSingleBean(ReadinessCheckListener.class)
+                        .hasSingleBean(HealthCheckerProcessor.class)
+                        .hasSingleBean(HealthIndicatorProcessor.class)
+                        .hasSingleBean(ReadinessCheckCallbackProcessor.class)
+                        .hasBean(ReadinessCheckListener.READINESS_HEALTH_CHECK_EXECUTOR_BEAN_NAME));
+    }
+
+    @Test
+    void runWithoutReflectionCacheAutoConfigurationShouldHaveReadinessBeans() {
+        new ApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(ReadinessAutoConfiguration.class))
+                .withPropertyValues("management.endpoints.web.exposure.include=readiness")
+                .run((context) -> assertThat(context)
+                        .doesNotHaveBean(ReflectionCache.class)
                         .hasSingleBean(ReadinessCheckListener.class)
                         .hasSingleBean(HealthCheckerProcessor.class)
                         .hasSingleBean(HealthIndicatorProcessor.class)

--- a/sofa-boot-project/sofa-boot-actuator-autoconfigure/src/test/java/com/alipay/sofa/boot/actuator/autoconfigure/health/ReadinessAutoConfigurationTests.java
+++ b/sofa-boot-project/sofa-boot-actuator-autoconfigure/src/test/java/com/alipay/sofa/boot/actuator/autoconfigure/health/ReadinessAutoConfigurationTests.java
@@ -22,6 +22,7 @@ import com.alipay.sofa.boot.actuator.health.HealthIndicatorProcessor;
 import com.alipay.sofa.boot.actuator.health.ModuleHealthChecker;
 import com.alipay.sofa.boot.actuator.health.ReadinessCheckCallbackProcessor;
 import com.alipay.sofa.boot.actuator.health.ReadinessCheckListener;
+import com.alipay.sofa.boot.autoconfigure.reflection.ReflectionCacheAutoConfiguration;
 import com.alipay.sofa.boot.autoconfigure.isle.SofaModuleAutoConfiguration;
 import com.alipay.sofa.boot.autoconfigure.runtime.SofaRuntimeAutoConfiguration;
 import com.alipay.sofa.boot.isle.ApplicationRuntimeModel;
@@ -49,7 +50,8 @@ public class ReadinessAutoConfigurationTests {
     private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
                                                              .withConfiguration(
                                                                  AutoConfigurations
-                                                                     .of(ReadinessAutoConfiguration.class))
+                                                                     .of(ReflectionCacheAutoConfiguration.class,
+                                                                         ReadinessAutoConfiguration.class))
                                                              .withPropertyValues(
                                                                  "management.endpoints.web.exposure.include=readiness");
 

--- a/sofa-boot-project/sofa-boot-actuator-autoconfigure/src/test/java/com/alipay/sofa/boot/actuator/autoconfigure/health/ReadinessEndpointAutoConfigurationTests.java
+++ b/sofa-boot-project/sofa-boot-actuator-autoconfigure/src/test/java/com/alipay/sofa/boot/actuator/autoconfigure/health/ReadinessEndpointAutoConfigurationTests.java
@@ -19,6 +19,7 @@ package com.alipay.sofa.boot.actuator.autoconfigure.health;
 import com.alipay.sofa.boot.actuator.health.ReadinessEndpoint;
 import com.alipay.sofa.boot.actuator.health.ReadinessEndpointWebExtension;
 import com.alipay.sofa.boot.actuator.health.ReadinessHttpCodeStatusMapper;
+import com.alipay.sofa.boot.autoconfigure.reflection.ReflectionCacheAutoConfiguration;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.actuate.autoconfigure.health.HealthEndpointAutoConfiguration;
 import org.springframework.boot.actuate.health.HttpCodeStatusMapper;
@@ -38,7 +39,8 @@ public class ReadinessEndpointAutoConfigurationTests {
 
     private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
                                                              .withConfiguration(AutoConfigurations
-                                                                 .of(ReadinessEndpointAutoConfiguration.class,
+                                                                 .of(ReflectionCacheAutoConfiguration.class,
+                                                                     ReadinessEndpointAutoConfiguration.class,
                                                                      ReadinessAutoConfiguration.class,
                                                                      HealthEndpointAutoConfiguration.class));
 

--- a/sofa-boot-project/sofa-boot-actuator-autoconfigure/src/test/java/com/alipay/sofa/boot/actuator/autoconfigure/reflection/ReflectionCacheEndpointAutoConfigurationTests.java
+++ b/sofa-boot-project/sofa-boot-actuator-autoconfigure/src/test/java/com/alipay/sofa/boot/actuator/autoconfigure/reflection/ReflectionCacheEndpointAutoConfigurationTests.java
@@ -28,7 +28,6 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Tests for {@link ReflectionCacheEndpointAutoConfiguration}.
  *
  * @author xiaosiyuan
- * @since 4.5.0
  */
 public class ReflectionCacheEndpointAutoConfigurationTests {
 

--- a/sofa-boot-project/sofa-boot-actuator-autoconfigure/src/test/java/com/alipay/sofa/boot/actuator/autoconfigure/reflection/ReflectionCacheEndpointAutoConfigurationTests.java
+++ b/sofa-boot-project/sofa-boot-actuator-autoconfigure/src/test/java/com/alipay/sofa/boot/actuator/autoconfigure/reflection/ReflectionCacheEndpointAutoConfigurationTests.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.boot.actuator.autoconfigure.reflection;
+
+import com.alipay.sofa.boot.actuator.reflection.ReflectionCacheEndpoint;
+import com.alipay.sofa.boot.autoconfigure.reflection.ReflectionCacheAutoConfiguration;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link ReflectionCacheEndpointAutoConfiguration}.
+ *
+ * @author xiaosiyuan
+ * @since 4.5.0
+ */
+public class ReflectionCacheEndpointAutoConfigurationTests {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+                                                             .withConfiguration(AutoConfigurations
+                                                                 .of(ReflectionCacheAutoConfiguration.class,
+                                                                     ReflectionCacheEndpointAutoConfiguration.class));
+
+    @Test
+    void runShouldHaveEndpointBean() {
+        this.contextRunner.withPropertyValues(
+            "management.endpoints.web.exposure.include=reflection-cache")
+                .run((context) -> assertThat(context)
+                    .hasSingleBean(ReflectionCacheEndpoint.class));
+    }
+
+    @Test
+    void runWhenNotExposedShouldNotHaveEndpointBean() {
+        this.contextRunner.run(
+            (context) -> assertThat(context).doesNotHaveBean(ReflectionCacheEndpoint.class));
+    }
+
+    @Test
+    void runWhenReflectionCacheBeanMissingShouldNotHaveEndpointBean() {
+        new ApplicationContextRunner().withConfiguration(
+            AutoConfigurations.of(ReflectionCacheEndpointAutoConfiguration.class))
+                .withPropertyValues("management.endpoints.web.exposure.include=reflection-cache")
+                .run((context) -> assertThat(context)
+                    .doesNotHaveBean(ReflectionCacheEndpoint.class));
+    }
+}

--- a/sofa-boot-project/sofa-boot-actuator-autoconfigure/src/test/java/com/alipay/sofa/boot/actuator/autoconfigure/rpc/RpcActuatorAutoConfigurationTests.java
+++ b/sofa-boot-project/sofa-boot-actuator-autoconfigure/src/test/java/com/alipay/sofa/boot/actuator/autoconfigure/rpc/RpcActuatorAutoConfigurationTests.java
@@ -20,6 +20,7 @@ import com.alipay.sofa.boot.actuator.autoconfigure.health.ReadinessAutoConfigura
 import com.alipay.sofa.boot.actuator.rpc.HealthCheckProviderConfigDelayRegisterChecker;
 import com.alipay.sofa.boot.actuator.rpc.RpcAfterHealthCheckCallback;
 import com.alipay.sofa.boot.actuator.rpc.SofaRpcEndpoint;
+import com.alipay.sofa.boot.autoconfigure.reflection.ReflectionCacheAutoConfiguration;
 import com.alipay.sofa.rpc.boot.context.RpcStartApplicationListener;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
@@ -46,7 +47,8 @@ public class RpcActuatorAutoConfigurationTests {
     @Test
     void runShouldHaveHealthCheckProviderConfigDelayRegisterChecker() {
         this.contextRunner
-                .withUserConfiguration(ReadinessAutoConfiguration.class)
+                .withConfiguration(AutoConfigurations.of(ReflectionCacheAutoConfiguration.class,
+                    ReadinessAutoConfiguration.class))
                 .withBean(RpcStartApplicationListener.class)
                 .run((context) -> assertThat(context)
                         .hasSingleBean(HealthCheckProviderConfigDelayRegisterChecker.class));

--- a/sofa-boot-project/sofa-boot-actuator/src/main/java/com/alipay/sofa/boot/actuator/health/HealthIndicatorProcessor.java
+++ b/sofa-boot-project/sofa-boot-actuator/src/main/java/com/alipay/sofa/boot/actuator/health/HealthIndicatorProcessor.java
@@ -18,6 +18,7 @@ package com.alipay.sofa.boot.actuator.health;
 
 import com.alipay.sofa.boot.log.ErrorCode;
 import com.alipay.sofa.boot.log.SofaBootLoggerFactory;
+import com.alipay.sofa.boot.reflection.ReflectionCache;
 import com.alipay.sofa.boot.startup.BaseStat;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
@@ -98,6 +99,8 @@ public class HealthIndicatorProcessor implements ApplicationContextAware {
 
     private long                                   parallelCheckTimeout;
 
+    private ReflectionCache                        reflectionCache;
+
     static {
         REACTOR_CLASS_EXIST = ClassUtils.isPresent(REACTOR_CLASS, null);
     }
@@ -133,7 +136,7 @@ public class HealthIndicatorProcessor implements ApplicationContextAware {
         excludedIndicators = new HashSet<>();
         for (String exclude : excludes) {
             try {
-                Class<?> c = Class.forName(exclude);
+                Class<?> c = loadClass(exclude);
                 excludedIndicators.add(c);
             } catch (Throwable e) {
                 logger.warn("Unable to find excluded HealthIndicator class {}, just ignore it.",
@@ -293,6 +296,15 @@ public class HealthIndicatorProcessor implements ApplicationContextAware {
 
     public void setParallelCheckTimeout(long parallelCheckTimeout) {
         this.parallelCheckTimeout = parallelCheckTimeout;
+    }
+
+    public void setReflectionCache(ReflectionCache reflectionCache) {
+        this.reflectionCache = reflectionCache;
+    }
+
+    private Class<?> loadClass(String className) throws ClassNotFoundException {
+        return reflectionCache != null ? reflectionCache.forName(className) : Class
+            .forName(className);
     }
 
     public Map<String, HealthCheckerConfig> getHealthIndicatorConfig() {

--- a/sofa-boot-project/sofa-boot-actuator/src/main/java/com/alipay/sofa/boot/actuator/reflection/ReflectionCacheEndpoint.java
+++ b/sofa-boot-project/sofa-boot-actuator/src/main/java/com/alipay/sofa/boot/actuator/reflection/ReflectionCacheEndpoint.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.boot.actuator.reflection;
+
+import com.alipay.sofa.boot.reflection.ReflectionCache;
+import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
+import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
+import org.springframework.boot.actuate.endpoint.annotation.WriteOperation;
+
+/**
+ * Endpoint for viewing and clearing the reflection cache.
+ *
+ * @author xiaosiyuan
+ * @since 4.5.0
+ */
+@Endpoint(id = "reflection-cache")
+public class ReflectionCacheEndpoint {
+
+    private final ReflectionCache reflectionCache;
+
+    public ReflectionCacheEndpoint(ReflectionCache reflectionCache) {
+        this.reflectionCache = reflectionCache;
+    }
+
+    @ReadOperation
+    public ReflectionCache.CacheStats stats() {
+        return reflectionCache.getStats();
+    }
+
+    @WriteOperation
+    public ReflectionCache.CacheStats clear() {
+        reflectionCache.clear();
+        return reflectionCache.getStats();
+    }
+}

--- a/sofa-boot-project/sofa-boot-actuator/src/main/java/com/alipay/sofa/boot/actuator/reflection/ReflectionCacheEndpoint.java
+++ b/sofa-boot-project/sofa-boot-actuator/src/main/java/com/alipay/sofa/boot/actuator/reflection/ReflectionCacheEndpoint.java
@@ -25,7 +25,6 @@ import org.springframework.boot.actuate.endpoint.annotation.WriteOperation;
  * Endpoint for viewing and clearing the reflection cache.
  *
  * @author xiaosiyuan
- * @since 4.5.0
  */
 @Endpoint(id = "reflection-cache")
 public class ReflectionCacheEndpoint {

--- a/sofa-boot-project/sofa-boot-actuator/src/main/java/com/alipay/sofa/boot/actuator/reflection/ReflectionCacheEndpoint.java
+++ b/sofa-boot-project/sofa-boot-actuator/src/main/java/com/alipay/sofa/boot/actuator/reflection/ReflectionCacheEndpoint.java
@@ -17,6 +17,7 @@
 package com.alipay.sofa.boot.actuator.reflection;
 
 import com.alipay.sofa.boot.reflection.ReflectionCache;
+import org.springframework.boot.actuate.endpoint.Access;
 import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
 import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
 import org.springframework.boot.actuate.endpoint.annotation.WriteOperation;
@@ -26,7 +27,7 @@ import org.springframework.boot.actuate.endpoint.annotation.WriteOperation;
  *
  * @author xiaosiyuan
  */
-@Endpoint(id = "reflection-cache")
+@Endpoint(id = "reflection-cache", defaultAccess = Access.READ_ONLY)
 public class ReflectionCacheEndpoint {
 
     private final ReflectionCache reflectionCache;

--- a/sofa-boot-project/sofa-boot-actuator/src/test/java/com/alipay/sofa/boot/actuator/reflection/ReflectionCacheEndpointTests.java
+++ b/sofa-boot-project/sofa-boot-actuator/src/test/java/com/alipay/sofa/boot/actuator/reflection/ReflectionCacheEndpointTests.java
@@ -25,7 +25,6 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Tests for {@link ReflectionCacheEndpoint}.
  *
  * @author xiaosiyuan
- * @since 4.5.0
  */
 public class ReflectionCacheEndpointTests {
 

--- a/sofa-boot-project/sofa-boot-actuator/src/test/java/com/alipay/sofa/boot/actuator/reflection/ReflectionCacheEndpointTests.java
+++ b/sofa-boot-project/sofa-boot-actuator/src/test/java/com/alipay/sofa/boot/actuator/reflection/ReflectionCacheEndpointTests.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.boot.actuator.reflection;
+
+import com.alipay.sofa.boot.reflection.ReflectionCache;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link ReflectionCacheEndpoint}.
+ *
+ * @author xiaosiyuan
+ * @since 4.5.0
+ */
+public class ReflectionCacheEndpointTests {
+
+    @Test
+    void statsShouldExposeReflectionCacheState() throws Exception {
+        ReflectionCache reflectionCache = new ReflectionCache();
+        ReflectionCacheEndpoint endpoint = new ReflectionCacheEndpoint(reflectionCache);
+
+        reflectionCache.forName(String.class.getName());
+        reflectionCache.forName(String.class.getName());
+
+        ReflectionCache.CacheStats stats = endpoint.stats();
+        assertThat(stats.isEnabled()).isTrue();
+        assertThat(stats.getClassHitCount()).isEqualTo(1);
+        assertThat(stats.getClassMissCount()).isEqualTo(1);
+        assertThat(stats.getClassCacheSize()).isEqualTo(1);
+    }
+
+    @Test
+    void clearShouldResetReflectionCacheState() throws Exception {
+        ReflectionCache reflectionCache = new ReflectionCache();
+        ReflectionCacheEndpoint endpoint = new ReflectionCacheEndpoint(reflectionCache);
+
+        reflectionCache.forName(String.class.getName());
+        reflectionCache.findMethod(String.class, "trim");
+        reflectionCache.getDeclaredConstructor(String.class, String.class);
+
+        ReflectionCache.CacheStats stats = endpoint.clear();
+        assertThat(stats.getTotalHitCount()).isZero();
+        assertThat(stats.getTotalMissCount()).isZero();
+        assertThat(stats.getClassCacheSize()).isZero();
+        assertThat(stats.getMethodCacheSize()).isZero();
+        assertThat(stats.getConstructorCacheSize()).isZero();
+    }
+}

--- a/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/reflection/ReflectionCacheAutoConfiguration.java
+++ b/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/reflection/ReflectionCacheAutoConfiguration.java
@@ -26,7 +26,6 @@ import org.springframework.context.annotation.Bean;
  * Configures {@link ReflectionCache}.
  *
  * @author xiaosiyuan
- * @since 4.5.0
  */
 @AutoConfiguration
 @EnableConfigurationProperties(ReflectionCacheProperties.class)

--- a/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/reflection/ReflectionCacheAutoConfiguration.java
+++ b/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/reflection/ReflectionCacheAutoConfiguration.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.boot.autoconfigure.reflection;
+
+import com.alipay.sofa.boot.reflection.ReflectionCache;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * Configures {@link ReflectionCache}.
+ *
+ * @author xiaosiyuan
+ * @since 4.5.0
+ */
+@AutoConfiguration
+@EnableConfigurationProperties(ReflectionCacheProperties.class)
+public class ReflectionCacheAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean
+    public ReflectionCache reflectionCache(ReflectionCacheProperties reflectionCacheProperties) {
+        return new ReflectionCache(reflectionCacheProperties.isEnabled());
+    }
+}

--- a/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/reflection/ReflectionCacheProperties.java
+++ b/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/reflection/ReflectionCacheProperties.java
@@ -22,7 +22,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * Properties for {@link ReflectionCacheAutoConfiguration}.
  *
  * @author xiaosiyuan
- * @since 4.5.0
  */
 @ConfigurationProperties("sofa.boot.reflection.cache")
 public class ReflectionCacheProperties {

--- a/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/reflection/ReflectionCacheProperties.java
+++ b/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/reflection/ReflectionCacheProperties.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.boot.autoconfigure.reflection;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Properties for {@link ReflectionCacheAutoConfiguration}.
+ *
+ * @author xiaosiyuan
+ * @since 4.5.0
+ */
+@ConfigurationProperties("sofa.boot.reflection.cache")
+public class ReflectionCacheProperties {
+
+    /**
+     * Enables the reflection cache.
+     */
+    private boolean enabled = true;
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+}

--- a/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/tracer/datasource/DataSourceAutoConfiguration.java
+++ b/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/tracer/datasource/DataSourceAutoConfiguration.java
@@ -17,6 +17,7 @@
 package com.alipay.sofa.boot.autoconfigure.tracer.datasource;
 
 import com.alipay.common.tracer.core.configuration.SofaTracerConfiguration;
+import com.alipay.sofa.boot.reflection.ReflectionCache;
 import com.alipay.sofa.boot.tracer.datasource.DataSourceBeanPostProcessor;
 import com.alipay.sofa.tracer.plugins.datasource.SmartDataSource;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
@@ -41,10 +42,12 @@ public class DataSourceAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    public static DataSourceBeanPostProcessor dataSourceBeanPostProcessor(Environment environment) {
+    public static DataSourceBeanPostProcessor dataSourceBeanPostProcessor(Environment environment,
+                                                                          ReflectionCache reflectionCache) {
         String appName = environment.getProperty(SofaTracerConfiguration.TRACER_APPNAME_KEY);
         DataSourceBeanPostProcessor dataSourceBeanPostProcessor = new DataSourceBeanPostProcessor();
         dataSourceBeanPostProcessor.setAppName(appName);
+        dataSourceBeanPostProcessor.setReflectionCache(reflectionCache);
         return dataSourceBeanPostProcessor;
     }
 }

--- a/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/tracer/datasource/DataSourceAutoConfiguration.java
+++ b/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/tracer/datasource/DataSourceAutoConfiguration.java
@@ -20,6 +20,7 @@ import com.alipay.common.tracer.core.configuration.SofaTracerConfiguration;
 import com.alipay.sofa.boot.reflection.ReflectionCache;
 import com.alipay.sofa.boot.tracer.datasource.DataSourceBeanPostProcessor;
 import com.alipay.sofa.tracer.plugins.datasource.SmartDataSource;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -43,11 +44,11 @@ public class DataSourceAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean
     public static DataSourceBeanPostProcessor dataSourceBeanPostProcessor(Environment environment,
-                                                                          ReflectionCache reflectionCache) {
+                                                                          ObjectProvider<ReflectionCache> reflectionCacheProvider) {
         String appName = environment.getProperty(SofaTracerConfiguration.TRACER_APPNAME_KEY);
         DataSourceBeanPostProcessor dataSourceBeanPostProcessor = new DataSourceBeanPostProcessor();
         dataSourceBeanPostProcessor.setAppName(appName);
-        dataSourceBeanPostProcessor.setReflectionCache(reflectionCache);
+        reflectionCacheProvider.ifAvailable(dataSourceBeanPostProcessor::setReflectionCache);
         return dataSourceBeanPostProcessor;
     }
 }

--- a/sofa-boot-project/sofa-boot-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/sofa-boot-project/sofa-boot-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,3 +1,4 @@
+com.alipay.sofa.boot.autoconfigure.reflection.ReflectionCacheAutoConfiguration
 com.alipay.sofa.boot.autoconfigure.runtime.SofaRuntimeAutoConfiguration
 com.alipay.sofa.boot.autoconfigure.isle.SofaModuleAutoConfiguration
 com.alipay.sofa.boot.autoconfigure.rpc.SofaRpcAutoConfiguration

--- a/sofa-boot-project/sofa-boot-autoconfigure/src/test/java/com/alipay/sofa/boot/autoconfigure/reflection/ReflectionCacheAutoConfigurationTests.java
+++ b/sofa-boot-project/sofa-boot-autoconfigure/src/test/java/com/alipay/sofa/boot/autoconfigure/reflection/ReflectionCacheAutoConfigurationTests.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.boot.autoconfigure.reflection;
+
+import com.alipay.sofa.boot.reflection.ReflectionCache;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link ReflectionCacheAutoConfiguration}.
+ *
+ * @author xiaosiyuan
+ * @since 4.5.0
+ */
+public class ReflectionCacheAutoConfigurationTests {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+                                                             .withConfiguration(AutoConfigurations
+                                                                 .of(ReflectionCacheAutoConfiguration.class));
+
+    @Test
+    void registerReflectionCacheByDefault() {
+        this.contextRunner.run((context) -> {
+            assertThat(context).hasSingleBean(ReflectionCache.class);
+            assertThat(context.getBean(ReflectionCache.class).isEnabled()).isTrue();
+        });
+    }
+
+    @Test
+    void disabledPropertyShouldCreateDisabledReflectionCache() {
+        this.contextRunner.withPropertyValues("sofa.boot.reflection.cache.enabled=false")
+                .run((context) -> assertThat(context.getBean(ReflectionCache.class).isEnabled()).isFalse());
+    }
+
+    @Test
+    void backOffWhenCustomReflectionCacheExists() {
+        ReflectionCache reflectionCache = new ReflectionCache(false);
+        this.contextRunner.withBean(ReflectionCache.class, () -> reflectionCache)
+                .run((context) -> assertThat(context.getBean(ReflectionCache.class))
+                    .isSameAs(reflectionCache));
+    }
+}

--- a/sofa-boot-project/sofa-boot-autoconfigure/src/test/java/com/alipay/sofa/boot/autoconfigure/reflection/ReflectionCacheAutoConfigurationTests.java
+++ b/sofa-boot-project/sofa-boot-autoconfigure/src/test/java/com/alipay/sofa/boot/autoconfigure/reflection/ReflectionCacheAutoConfigurationTests.java
@@ -27,7 +27,6 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Tests for {@link ReflectionCacheAutoConfiguration}.
  *
  * @author xiaosiyuan
- * @since 4.5.0
  */
 public class ReflectionCacheAutoConfigurationTests {
 

--- a/sofa-boot-project/sofa-boot-autoconfigure/src/test/java/com/alipay/sofa/boot/autoconfigure/tracer/datasource/DataSourceAutoConfigurationTests.java
+++ b/sofa-boot-project/sofa-boot-autoconfigure/src/test/java/com/alipay/sofa/boot/autoconfigure/tracer/datasource/DataSourceAutoConfigurationTests.java
@@ -17,6 +17,7 @@
 package com.alipay.sofa.boot.autoconfigure.tracer.datasource;
 
 import com.alipay.sofa.boot.autoconfigure.reflection.ReflectionCacheAutoConfiguration;
+import com.alipay.sofa.boot.reflection.ReflectionCache;
 import com.alipay.sofa.boot.tracer.datasource.DataSourceBeanPostProcessor;
 import com.alipay.sofa.tracer.plugins.datasource.SmartDataSource;
 import org.junit.jupiter.api.Test;
@@ -43,6 +44,15 @@ public class DataSourceAutoConfigurationTests {
     public void registerDataSourcePostProcessors() {
         this.contextRunner
                 .run((context) -> assertThat(context)
+                        .hasSingleBean(DataSourceBeanPostProcessor.class));
+    }
+
+    @Test
+    public void registerDataSourcePostProcessorsWithoutReflectionCacheAutoConfiguration() {
+        new ApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(DataSourceAutoConfiguration.class))
+                .run((context) -> assertThat(context)
+                        .doesNotHaveBean(ReflectionCache.class)
                         .hasSingleBean(DataSourceBeanPostProcessor.class));
     }
 

--- a/sofa-boot-project/sofa-boot-autoconfigure/src/test/java/com/alipay/sofa/boot/autoconfigure/tracer/datasource/DataSourceAutoConfigurationTests.java
+++ b/sofa-boot-project/sofa-boot-autoconfigure/src/test/java/com/alipay/sofa/boot/autoconfigure/tracer/datasource/DataSourceAutoConfigurationTests.java
@@ -16,6 +16,7 @@
  */
 package com.alipay.sofa.boot.autoconfigure.tracer.datasource;
 
+import com.alipay.sofa.boot.autoconfigure.reflection.ReflectionCacheAutoConfiguration;
 import com.alipay.sofa.boot.tracer.datasource.DataSourceBeanPostProcessor;
 import com.alipay.sofa.tracer.plugins.datasource.SmartDataSource;
 import org.junit.jupiter.api.Test;
@@ -35,7 +36,8 @@ public class DataSourceAutoConfigurationTests {
 
     private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
                                                              .withConfiguration(AutoConfigurations
-                                                                 .of(DataSourceAutoConfiguration.class));
+                                                                 .of(ReflectionCacheAutoConfiguration.class,
+                                                                     DataSourceAutoConfiguration.class));
 
     @Test
     public void registerDataSourcePostProcessors() {

--- a/sofa-boot-project/sofa-boot-core/tracer-sofa-boot/src/main/java/com/alipay/sofa/boot/tracer/datasource/DataSourceBeanPostProcessor.java
+++ b/sofa-boot-project/sofa-boot-core/tracer-sofa-boot/src/main/java/com/alipay/sofa/boot/tracer/datasource/DataSourceBeanPostProcessor.java
@@ -17,6 +17,7 @@
 package com.alipay.sofa.boot.tracer.datasource;
 
 import com.alipay.sofa.boot.context.processor.SingletonSofaPostProcessor;
+import com.alipay.sofa.boot.reflection.ReflectionCache;
 import com.alipay.sofa.tracer.plugins.datasource.SmartDataSource;
 import com.alipay.sofa.tracer.plugins.datasource.utils.DataSourceUtils;
 import org.springframework.beans.BeansException;
@@ -42,7 +43,9 @@ import static com.alipay.common.tracer.core.configuration.SofaTracerConfiguratio
 @SingletonSofaPostProcessor
 public class DataSourceBeanPostProcessor implements BeanPostProcessor, PriorityOrdered {
 
-    private String appName;
+    private String          appName;
+
+    private ReflectionCache reflectionCache;
 
     @Override
     public Object postProcessAfterInitialization(Object bean, String beanName)
@@ -73,7 +76,7 @@ public class DataSourceBeanPostProcessor implements BeanPostProcessor, PriorityO
         }
 
         try {
-            Method urlMethod = ReflectionUtils.findMethod(bean.getClass(), getUrlMethodName);
+            Method urlMethod = findMethod(bean.getClass(), getUrlMethodName);
             urlMethod.setAccessible(true);
             url = (String) urlMethod.invoke(bean);
         } catch (Throwable throwable) {
@@ -99,5 +102,14 @@ public class DataSourceBeanPostProcessor implements BeanPostProcessor, PriorityO
 
     public void setAppName(String appName) {
         this.appName = appName;
+    }
+
+    public void setReflectionCache(ReflectionCache reflectionCache) {
+        this.reflectionCache = reflectionCache;
+    }
+
+    private Method findMethod(Class<?> targetClass, String methodName) {
+        return reflectionCache != null ? reflectionCache.findMethod(targetClass, methodName)
+            : ReflectionUtils.findMethod(targetClass, methodName);
     }
 }

--- a/sofa-boot-project/sofa-boot/src/main/java/com/alipay/sofa/boot/constant/SofaBootConstants.java
+++ b/sofa-boot-project/sofa-boot/src/main/java/com/alipay/sofa/boot/constant/SofaBootConstants.java
@@ -88,7 +88,7 @@ public class SofaBootConstants {
     /**
      * Default exposure web endpoint list
      */
-    public static final String SOFA_DEFAULT_ENDPOINTS_WEB_EXPOSURE_VALUE       = "info,health,readiness,startup,beans,components,rpc,isle,threadpool,sbom";
+    public static final String SOFA_DEFAULT_ENDPOINTS_WEB_EXPOSURE_VALUE       = "info,health,readiness,startup,beans,components,rpc,isle,threadpool,sbom,reflection-cache";
 
     /**
      * CPU core

--- a/sofa-boot-project/sofa-boot/src/main/java/com/alipay/sofa/boot/reflection/ReflectionCache.java
+++ b/sofa-boot-project/sofa-boot/src/main/java/com/alipay/sofa/boot/reflection/ReflectionCache.java
@@ -25,6 +25,7 @@ import java.util.Arrays;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 
@@ -305,20 +306,31 @@ public class ReflectionCache {
 
     private static final class LookupStore<K, V extends LookupResult> {
 
-        private final ConcurrentHashMap<K, V> cache     = new ConcurrentHashMap<>();
+        private final ConcurrentHashMap<K, V> cache         = new ConcurrentHashMap<>();
 
-        private final AtomicLong              hitCount  = new AtomicLong();
+        private final AtomicLong              hitCount      = new AtomicLong();
 
-        private final AtomicLong              missCount = new AtomicLong();
+        private final AtomicLong              missCount     = new AtomicLong();
+
+        private final AtomicInteger           missCacheSize = new AtomicInteger();
 
         private V get(K key, Function<K, V> loader) {
+            V result = cache.get(key);
+            if (result != null) {
+                hitCount.incrementAndGet();
+                return result;
+            }
+
             AtomicBoolean cacheMiss = new AtomicBoolean(false);
-            V result = cache.computeIfAbsent(key, cacheKey -> {
+            result = cache.computeIfAbsent(key, cacheKey -> {
                 cacheMiss.set(true);
                 return loader.apply(cacheKey);
             });
             if (cacheMiss.get()) {
                 missCount.incrementAndGet();
+                if (result.isMiss()) {
+                    missCacheSize.incrementAndGet();
+                }
             } else {
                 hitCount.incrementAndGet();
             }
@@ -327,13 +339,14 @@ public class ReflectionCache {
 
         private LookupStats getStats() {
             return new LookupStats(hitCount.get(), missCount.get(), cache.size(),
-                (int) cache.values().stream().filter(LookupResult::isMiss).count());
+                missCacheSize.get());
         }
 
         private void clear() {
             cache.clear();
             hitCount.set(0);
             missCount.set(0);
+            missCacheSize.set(0);
         }
     }
 

--- a/sofa-boot-project/sofa-boot/src/main/java/com/alipay/sofa/boot/reflection/ReflectionCache.java
+++ b/sofa-boot-project/sofa-boot/src/main/java/com/alipay/sofa/boot/reflection/ReflectionCache.java
@@ -32,7 +32,6 @@ import java.util.function.Function;
  * Caches repeated reflection lookups.
  *
  * @author xiaosiyuan
- * @since 4.5.0
  */
 public class ReflectionCache {
 

--- a/sofa-boot-project/sofa-boot/src/main/java/com/alipay/sofa/boot/reflection/ReflectionCache.java
+++ b/sofa-boot-project/sofa-boot/src/main/java/com/alipay/sofa/boot/reflection/ReflectionCache.java
@@ -1,0 +1,512 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.boot.reflection;
+
+import org.springframework.lang.Nullable;
+import org.springframework.util.ReflectionUtils;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Function;
+
+/**
+ * Caches repeated reflection lookups.
+ *
+ * @author xiaosiyuan
+ * @since 4.5.0
+ */
+public class ReflectionCache {
+
+    private static final Class<?>[]                                    EMPTY_PARAMETER_TYPES = new Class<?>[0];
+
+    private final LookupStore<ClassKey, ClassLookupResult>             classLookup           = new LookupStore<>();
+
+    private final LookupStore<MethodKey, MethodLookupResult>           methodLookup          = new LookupStore<>();
+
+    private final LookupStore<ConstructorKey, ConstructorLookupResult> constructorLookup     = new LookupStore<>();
+
+    private volatile boolean                                           enabled;
+
+    public ReflectionCache() {
+        this(true);
+    }
+
+    public ReflectionCache(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+        if (!enabled) {
+            clear();
+        }
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public Class<?> forName(String className) throws ClassNotFoundException {
+        return forName(className, null);
+    }
+
+    public Class<?> forName(String className, @Nullable ClassLoader classLoader)
+                                                                                throws ClassNotFoundException {
+        if (!enabled) {
+            return doForName(className, classLoader);
+        }
+
+        ClassLookupResult result = classLookup.get(new ClassKey(className, classLoader), cacheKey -> {
+            try {
+                return ClassLookupResult.found(doForName(cacheKey.className, cacheKey.classLoader));
+            } catch (ClassNotFoundException exception) {
+                return ClassLookupResult.missed();
+            }
+        });
+        if (result.isMiss()) {
+            throw new ClassNotFoundException(className);
+        }
+        return result.type;
+    }
+
+    @Nullable
+    public Method findMethod(Class<?> targetClass, String methodName, Class<?>... parameterTypes) {
+        Class<?>[] normalizedParameterTypes = normalizeParameterTypes(parameterTypes);
+        if (!enabled) {
+            return doFindMethod(targetClass, methodName, normalizedParameterTypes);
+        }
+
+        MethodLookupResult result = methodLookup.get(new MethodKey(targetClass, methodName,
+            normalizedParameterTypes), cacheKey -> new MethodLookupResult(
+                doFindMethod(cacheKey.targetClass, cacheKey.methodName, cacheKey.parameterTypes)));
+        return result.method;
+    }
+
+    public <T> Constructor<T> getDeclaredConstructor(Class<T> targetClass,
+                                                     Class<?>... parameterTypes)
+                                                                                throws NoSuchMethodException {
+        Class<?>[] normalizedParameterTypes = normalizeParameterTypes(parameterTypes);
+        if (!enabled) {
+            return doGetDeclaredConstructor(targetClass, normalizedParameterTypes);
+        }
+
+        ConstructorLookupResult result = constructorLookup.get(new ConstructorKey(targetClass,
+            normalizedParameterTypes), cacheKey -> {
+            try {
+                Constructor<?> constructor = doGetDeclaredConstructor(cacheKey.targetClass,
+                    cacheKey.parameterTypes);
+                return ConstructorLookupResult.found(constructor);
+            } catch (NoSuchMethodException exception) {
+                return ConstructorLookupResult.missed();
+            }
+        });
+        if (result.isMiss()) {
+            throw new NoSuchMethodException(buildConstructorSignature(targetClass,
+                normalizedParameterTypes));
+        }
+        return castConstructor(result.constructor);
+    }
+
+    public CacheStats getStats() {
+        LookupStats classStats = classLookup.getStats();
+        LookupStats methodStats = methodLookup.getStats();
+        LookupStats constructorStats = constructorLookup.getStats();
+        return new CacheStats(enabled, classStats.hitCount, classStats.missCount,
+            classStats.cacheSize, classStats.missCacheSize, methodStats.hitCount,
+            methodStats.missCount, methodStats.cacheSize, methodStats.missCacheSize,
+            constructorStats.hitCount, constructorStats.missCount, constructorStats.cacheSize,
+            constructorStats.missCacheSize);
+    }
+
+    public void clear() {
+        classLookup.clear();
+        methodLookup.clear();
+        constructorLookup.clear();
+    }
+
+    private Class<?> doForName(String className, @Nullable ClassLoader classLoader)
+                                                                                   throws ClassNotFoundException {
+        if (classLoader == null) {
+            return Class.forName(className);
+        }
+        return Class.forName(className, true, classLoader);
+    }
+
+    @Nullable
+    private Method doFindMethod(Class<?> targetClass, String methodName, Class<?>[] parameterTypes) {
+        return ReflectionUtils.findMethod(targetClass, methodName, parameterTypes);
+    }
+
+    private <T> Constructor<T> doGetDeclaredConstructor(Class<T> targetClass,
+                                                        Class<?>[] parameterTypes)
+                                                                                  throws NoSuchMethodException {
+        Constructor<T> constructor = targetClass.getDeclaredConstructor(parameterTypes);
+        ReflectionUtils.makeAccessible(constructor);
+        return constructor;
+    }
+
+    private String buildConstructorSignature(Class<?> targetClass, Class<?>[] parameterTypes) {
+        String parameterTypeNames = Arrays.stream(parameterTypes).map(Class::getName).reduce(
+            (left, right) -> left + "," + right).orElse("");
+        return targetClass.getName() + ".<init>(" + parameterTypeNames + ")";
+    }
+
+    private Class<?>[] normalizeParameterTypes(@Nullable Class<?>[] parameterTypes) {
+        if (parameterTypes == null || parameterTypes.length == 0) {
+            return EMPTY_PARAMETER_TYPES;
+        }
+        return parameterTypes.clone();
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> Constructor<T> castConstructor(Constructor<?> constructor) {
+        return (Constructor<T>) constructor;
+    }
+
+    public static final class CacheStats {
+
+        private final boolean enabled;
+
+        private final long    classHitCount;
+
+        private final long    classMissCount;
+
+        private final int     classCacheSize;
+
+        private final int     classMissCacheSize;
+
+        private final long    methodHitCount;
+
+        private final long    methodMissCount;
+
+        private final int     methodCacheSize;
+
+        private final int     methodMissCacheSize;
+
+        private final long    constructorHitCount;
+
+        private final long    constructorMissCount;
+
+        private final int     constructorCacheSize;
+
+        private final int     constructorMissCacheSize;
+
+        public CacheStats(boolean enabled, long classHitCount, long classMissCount,
+                          int classCacheSize, int classMissCacheSize, long methodHitCount,
+                          long methodMissCount, int methodCacheSize, int methodMissCacheSize,
+                          long constructorHitCount, long constructorMissCount,
+                          int constructorCacheSize, int constructorMissCacheSize) {
+            this.enabled = enabled;
+            this.classHitCount = classHitCount;
+            this.classMissCount = classMissCount;
+            this.classCacheSize = classCacheSize;
+            this.classMissCacheSize = classMissCacheSize;
+            this.methodHitCount = methodHitCount;
+            this.methodMissCount = methodMissCount;
+            this.methodCacheSize = methodCacheSize;
+            this.methodMissCacheSize = methodMissCacheSize;
+            this.constructorHitCount = constructorHitCount;
+            this.constructorMissCount = constructorMissCount;
+            this.constructorCacheSize = constructorCacheSize;
+            this.constructorMissCacheSize = constructorMissCacheSize;
+        }
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public long getClassHitCount() {
+            return classHitCount;
+        }
+
+        public long getClassMissCount() {
+            return classMissCount;
+        }
+
+        public int getClassCacheSize() {
+            return classCacheSize;
+        }
+
+        public int getClassMissCacheSize() {
+            return classMissCacheSize;
+        }
+
+        public long getMethodHitCount() {
+            return methodHitCount;
+        }
+
+        public long getMethodMissCount() {
+            return methodMissCount;
+        }
+
+        public int getMethodCacheSize() {
+            return methodCacheSize;
+        }
+
+        public int getMethodMissCacheSize() {
+            return methodMissCacheSize;
+        }
+
+        public long getConstructorHitCount() {
+            return constructorHitCount;
+        }
+
+        public long getConstructorMissCount() {
+            return constructorMissCount;
+        }
+
+        public int getConstructorCacheSize() {
+            return constructorCacheSize;
+        }
+
+        public int getConstructorMissCacheSize() {
+            return constructorMissCacheSize;
+        }
+
+        public long getTotalHitCount() {
+            return classHitCount + methodHitCount + constructorHitCount;
+        }
+
+        public long getTotalMissCount() {
+            return classMissCount + methodMissCount + constructorMissCount;
+        }
+
+        public double getHitRate() {
+            long total = getTotalHitCount() + getTotalMissCount();
+            if (total == 0) {
+                return 0D;
+            }
+            return (double) getTotalHitCount() / total;
+        }
+    }
+
+    private interface LookupResult {
+
+        boolean isMiss();
+    }
+
+    private static final class LookupStore<K, V extends LookupResult> {
+
+        private final ConcurrentHashMap<K, V> cache     = new ConcurrentHashMap<>();
+
+        private final AtomicLong              hitCount  = new AtomicLong();
+
+        private final AtomicLong              missCount = new AtomicLong();
+
+        private V get(K key, Function<K, V> loader) {
+            AtomicBoolean cacheMiss = new AtomicBoolean(false);
+            V result = cache.computeIfAbsent(key, cacheKey -> {
+                cacheMiss.set(true);
+                return loader.apply(cacheKey);
+            });
+            if (cacheMiss.get()) {
+                missCount.incrementAndGet();
+            } else {
+                hitCount.incrementAndGet();
+            }
+            return result;
+        }
+
+        private LookupStats getStats() {
+            return new LookupStats(hitCount.get(), missCount.get(), cache.size(),
+                (int) cache.values().stream().filter(LookupResult::isMiss).count());
+        }
+
+        private void clear() {
+            cache.clear();
+            hitCount.set(0);
+            missCount.set(0);
+        }
+    }
+
+    private static final class LookupStats {
+
+        private final long hitCount;
+
+        private final long missCount;
+
+        private final int  cacheSize;
+
+        private final int  missCacheSize;
+
+        private LookupStats(long hitCount, long missCount, int cacheSize, int missCacheSize) {
+            this.hitCount = hitCount;
+            this.missCount = missCount;
+            this.cacheSize = cacheSize;
+            this.missCacheSize = missCacheSize;
+        }
+    }
+
+    private static final class ClassLookupResult implements LookupResult {
+
+        private final Class<?> type;
+
+        private final boolean  miss;
+
+        private ClassLookupResult(Class<?> type, boolean miss) {
+            this.type = type;
+            this.miss = miss;
+        }
+
+        private static ClassLookupResult found(Class<?> type) {
+            return new ClassLookupResult(type, false);
+        }
+
+        private static ClassLookupResult missed() {
+            return new ClassLookupResult(null, true);
+        }
+
+        @Override
+        public boolean isMiss() {
+            return miss;
+        }
+    }
+
+    private static final class MethodLookupResult implements LookupResult {
+
+        private final Method method;
+
+        private MethodLookupResult(Method method) {
+            this.method = method;
+        }
+
+        @Override
+        public boolean isMiss() {
+            return method == null;
+        }
+    }
+
+    private static final class ConstructorLookupResult implements LookupResult {
+
+        private final Constructor<?> constructor;
+
+        private final boolean        miss;
+
+        private ConstructorLookupResult(Constructor<?> constructor, boolean miss) {
+            this.constructor = constructor;
+            this.miss = miss;
+        }
+
+        private static ConstructorLookupResult found(Constructor<?> constructor) {
+            return new ConstructorLookupResult(constructor, false);
+        }
+
+        private static ConstructorLookupResult missed() {
+            return new ConstructorLookupResult(null, true);
+        }
+
+        @Override
+        public boolean isMiss() {
+            return miss;
+        }
+    }
+
+    private static final class ClassKey {
+
+        private final String      className;
+
+        private final ClassLoader classLoader;
+
+        private ClassKey(String className, @Nullable ClassLoader classLoader) {
+            this.className = className;
+            this.classLoader = classLoader;
+        }
+
+        @Override
+        public boolean equals(Object object) {
+            if (this == object) {
+                return true;
+            }
+            if (!(object instanceof ClassKey that)) {
+                return false;
+            }
+            return Objects.equals(className, that.className) && classLoader == that.classLoader;
+        }
+
+        @Override
+        public int hashCode() {
+            return 31 * className.hashCode() + System.identityHashCode(classLoader);
+        }
+    }
+
+    private static final class MethodKey {
+
+        private final Class<?>   targetClass;
+
+        private final String     methodName;
+
+        private final Class<?>[] parameterTypes;
+
+        private MethodKey(Class<?> targetClass, String methodName, Class<?>[] parameterTypes) {
+            this.targetClass = targetClass;
+            this.methodName = methodName;
+            this.parameterTypes = parameterTypes;
+        }
+
+        @Override
+        public boolean equals(Object object) {
+            if (this == object) {
+                return true;
+            }
+            if (!(object instanceof MethodKey that)) {
+                return false;
+            }
+            return Objects.equals(targetClass, that.targetClass)
+                   && Objects.equals(methodName, that.methodName)
+                   && Arrays.equals(parameterTypes, that.parameterTypes);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(targetClass, methodName, Arrays.hashCode(parameterTypes));
+        }
+    }
+
+    private static final class ConstructorKey {
+
+        private final Class<?>   targetClass;
+
+        private final Class<?>[] parameterTypes;
+
+        private ConstructorKey(Class<?> targetClass, Class<?>[] parameterTypes) {
+            this.targetClass = targetClass;
+            this.parameterTypes = parameterTypes;
+        }
+
+        @Override
+        public boolean equals(Object object) {
+            if (this == object) {
+                return true;
+            }
+            if (!(object instanceof ConstructorKey that)) {
+                return false;
+            }
+            return Objects.equals(targetClass, that.targetClass)
+                   && Arrays.equals(parameterTypes, that.parameterTypes);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(targetClass, Arrays.hashCode(parameterTypes));
+        }
+    }
+}

--- a/sofa-boot-project/sofa-boot/src/test/java/com/alipay/sofa/boot/reflection/ReflectionCacheTests.java
+++ b/sofa-boot-project/sofa-boot/src/test/java/com/alipay/sofa/boot/reflection/ReflectionCacheTests.java
@@ -28,7 +28,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * Tests for {@link ReflectionCache}.
  *
  * @author xiaosiyuan
- * @since 4.5.0
  */
 public class ReflectionCacheTests {
 

--- a/sofa-boot-project/sofa-boot/src/test/java/com/alipay/sofa/boot/reflection/ReflectionCacheTests.java
+++ b/sofa-boot-project/sofa-boot/src/test/java/com/alipay/sofa/boot/reflection/ReflectionCacheTests.java
@@ -118,6 +118,80 @@ public class ReflectionCacheTests {
         assertThat(stats.getConstructorCacheSize()).isZero();
     }
 
+    @Test
+    void setEnabledFalseShouldClearCacheState() throws Exception {
+        ReflectionCache reflectionCache = new ReflectionCache();
+
+        reflectionCache.forName(SampleTarget.class.getName());
+        reflectionCache.forName(SampleTarget.class.getName());
+        reflectionCache.findMethod(SampleTarget.class, "greet", String.class);
+        reflectionCache.findMethod(SampleTarget.class, "greet", String.class);
+        reflectionCache.getDeclaredConstructor(SampleTarget.class, String.class);
+        reflectionCache.getDeclaredConstructor(SampleTarget.class, String.class);
+
+        assertThat(reflectionCache.getStats().getTotalHitCount()).isEqualTo(3);
+        assertThat(reflectionCache.getStats().getTotalMissCount()).isEqualTo(3);
+
+        reflectionCache.setEnabled(false);
+
+        assertThat(reflectionCache.isEnabled()).isFalse();
+        ReflectionCache.CacheStats disabledStats = reflectionCache.getStats();
+        assertThat(disabledStats.getTotalHitCount()).isZero();
+        assertThat(disabledStats.getTotalMissCount()).isZero();
+        assertThat(disabledStats.getClassCacheSize()).isZero();
+        assertThat(disabledStats.getMethodCacheSize()).isZero();
+        assertThat(disabledStats.getConstructorCacheSize()).isZero();
+
+        assertThat(reflectionCache.forName(SampleTarget.class.getName())).isSameAs(
+            SampleTarget.class);
+        assertThat(reflectionCache.getStats().getTotalMissCount()).isZero();
+
+        reflectionCache.setEnabled(true);
+
+        assertThat(reflectionCache.isEnabled()).isTrue();
+        assertThat(reflectionCache.forName(SampleTarget.class.getName())).isSameAs(
+            SampleTarget.class);
+        assertThat(reflectionCache.getStats().getClassMissCount()).isEqualTo(1);
+    }
+
+    @Test
+    void clearShouldResetCacheState() throws Exception {
+        ReflectionCache reflectionCache = new ReflectionCache();
+
+        reflectionCache.forName(SampleTarget.class.getName());
+        reflectionCache.forName(SampleTarget.class.getName());
+        reflectionCache.findMethod(SampleTarget.class, "greet", String.class);
+        reflectionCache.findMethod(SampleTarget.class, "greet", String.class);
+        reflectionCache.getDeclaredConstructor(SampleTarget.class, String.class);
+        reflectionCache.getDeclaredConstructor(SampleTarget.class, String.class);
+        assertThatThrownBy(
+            () -> reflectionCache.forName("com.alipay.sofa.boot.reflection.DoesNotExist"))
+                .isInstanceOf(ClassNotFoundException.class);
+        assertThatThrownBy(
+            () -> reflectionCache.forName("com.alipay.sofa.boot.reflection.DoesNotExist"))
+                .isInstanceOf(ClassNotFoundException.class);
+        assertThat(reflectionCache.findMethod(SampleTarget.class, "missingMethod")).isNull();
+        assertThat(reflectionCache.findMethod(SampleTarget.class, "missingMethod")).isNull();
+        assertThatThrownBy(
+            () -> reflectionCache.getDeclaredConstructor(SampleTarget.class, Integer.class))
+                .isInstanceOf(NoSuchMethodException.class);
+        assertThatThrownBy(
+            () -> reflectionCache.getDeclaredConstructor(SampleTarget.class, Integer.class))
+                .isInstanceOf(NoSuchMethodException.class);
+
+        reflectionCache.clear();
+
+        ReflectionCache.CacheStats stats = reflectionCache.getStats();
+        assertThat(stats.getTotalHitCount()).isZero();
+        assertThat(stats.getTotalMissCount()).isZero();
+        assertThat(stats.getClassCacheSize()).isZero();
+        assertThat(stats.getMethodCacheSize()).isZero();
+        assertThat(stats.getConstructorCacheSize()).isZero();
+        assertThat(stats.getClassMissCacheSize()).isZero();
+        assertThat(stats.getMethodMissCacheSize()).isZero();
+        assertThat(stats.getConstructorMissCacheSize()).isZero();
+    }
+
     static class SampleTarget {
 
         private final String prefix;

--- a/sofa-boot-project/sofa-boot/src/test/java/com/alipay/sofa/boot/reflection/ReflectionCacheTests.java
+++ b/sofa-boot-project/sofa-boot/src/test/java/com/alipay/sofa/boot/reflection/ReflectionCacheTests.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.boot.reflection;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests for {@link ReflectionCache}.
+ *
+ * @author xiaosiyuan
+ * @since 4.5.0
+ */
+public class ReflectionCacheTests {
+
+    @Test
+    void cacheHitsShouldBeRecordedForSuccessfulLookups() throws Exception {
+        ReflectionCache reflectionCache = new ReflectionCache();
+
+        Class<?> type = reflectionCache.forName(SampleTarget.class.getName());
+        Class<?> cachedType = reflectionCache.forName(SampleTarget.class.getName());
+        Method method = reflectionCache.findMethod(SampleTarget.class, "greet", String.class);
+        Method cachedMethod = reflectionCache.findMethod(SampleTarget.class, "greet", String.class);
+        Constructor<SampleTarget> constructor = reflectionCache.getDeclaredConstructor(
+            SampleTarget.class, String.class);
+        Constructor<SampleTarget> cachedConstructor = reflectionCache.getDeclaredConstructor(
+            SampleTarget.class, String.class);
+
+        assertThat(type).isSameAs(SampleTarget.class);
+        assertThat(cachedType).isSameAs(type);
+        assertThat(method).isNotNull();
+        assertThat(cachedMethod).isSameAs(method);
+        assertThat(constructor).isNotNull();
+        assertThat(cachedConstructor).isSameAs(constructor);
+        assertThat(constructor.newInstance("SOFA").greet("Boot")).isEqualTo("SOFABoot");
+
+        ReflectionCache.CacheStats stats = reflectionCache.getStats();
+        assertThat(stats.isEnabled()).isTrue();
+        assertThat(stats.getClassHitCount()).isEqualTo(1);
+        assertThat(stats.getClassMissCount()).isEqualTo(1);
+        assertThat(stats.getClassCacheSize()).isEqualTo(1);
+        assertThat(stats.getMethodHitCount()).isEqualTo(1);
+        assertThat(stats.getMethodMissCount()).isEqualTo(1);
+        assertThat(stats.getMethodCacheSize()).isEqualTo(1);
+        assertThat(stats.getConstructorHitCount()).isEqualTo(1);
+        assertThat(stats.getConstructorMissCount()).isEqualTo(1);
+        assertThat(stats.getConstructorCacheSize()).isEqualTo(1);
+        assertThat(stats.getHitRate()).isEqualTo(0.5D);
+    }
+
+    @Test
+    void cacheMissesShouldAlsoBeCached() {
+        ReflectionCache reflectionCache = new ReflectionCache();
+
+        assertThatThrownBy(
+            () -> reflectionCache.forName("com.alipay.sofa.boot.reflection.DoesNotExist"))
+                .isInstanceOf(ClassNotFoundException.class);
+        assertThatThrownBy(
+            () -> reflectionCache.forName("com.alipay.sofa.boot.reflection.DoesNotExist"))
+                .isInstanceOf(ClassNotFoundException.class);
+        assertThat(reflectionCache.findMethod(SampleTarget.class, "missingMethod")).isNull();
+        assertThat(reflectionCache.findMethod(SampleTarget.class, "missingMethod")).isNull();
+        assertThatThrownBy(
+            () -> reflectionCache.getDeclaredConstructor(SampleTarget.class, Integer.class))
+                .isInstanceOf(NoSuchMethodException.class);
+        assertThatThrownBy(
+            () -> reflectionCache.getDeclaredConstructor(SampleTarget.class, Integer.class))
+                .isInstanceOf(NoSuchMethodException.class);
+
+        ReflectionCache.CacheStats stats = reflectionCache.getStats();
+        assertThat(stats.getClassHitCount()).isEqualTo(1);
+        assertThat(stats.getClassMissCount()).isEqualTo(1);
+        assertThat(stats.getClassMissCacheSize()).isEqualTo(1);
+        assertThat(stats.getMethodHitCount()).isEqualTo(1);
+        assertThat(stats.getMethodMissCount()).isEqualTo(1);
+        assertThat(stats.getMethodMissCacheSize()).isEqualTo(1);
+        assertThat(stats.getConstructorHitCount()).isEqualTo(1);
+        assertThat(stats.getConstructorMissCount()).isEqualTo(1);
+        assertThat(stats.getConstructorMissCacheSize()).isEqualTo(1);
+    }
+
+    @Test
+    void disabledCacheShouldBypassStatistics() throws Exception {
+        ReflectionCache reflectionCache = new ReflectionCache(false);
+
+        assertThat(reflectionCache.isEnabled()).isFalse();
+        assertThat(reflectionCache.forName(SampleTarget.class.getName())).isSameAs(
+            SampleTarget.class);
+        assertThat(reflectionCache.findMethod(SampleTarget.class, "greet", String.class))
+            .isNotNull();
+        assertThat(reflectionCache.getDeclaredConstructor(SampleTarget.class, String.class))
+            .isNotNull();
+
+        ReflectionCache.CacheStats stats = reflectionCache.getStats();
+        assertThat(stats.isEnabled()).isFalse();
+        assertThat(stats.getTotalHitCount()).isZero();
+        assertThat(stats.getTotalMissCount()).isZero();
+        assertThat(stats.getClassCacheSize()).isZero();
+        assertThat(stats.getMethodCacheSize()).isZero();
+        assertThat(stats.getConstructorCacheSize()).isZero();
+    }
+
+    static class SampleTarget {
+
+        private final String prefix;
+
+        private SampleTarget(String prefix) {
+            this.prefix = prefix;
+        }
+
+        public String greet(String suffix) {
+            return prefix + suffix;
+        }
+    }
+}

--- a/sofa-boot-tests/sofa-boot-smoke-tests/sofa-boot-smoke-tests-actuator/src/test/java/com/alipay/sofa/smoke/tests/actuator/reflection/ReflectionCacheEndpointUnrestrictedWebTests.java
+++ b/sofa-boot-tests/sofa-boot-smoke-tests/sofa-boot-smoke-tests-actuator/src/test/java/com/alipay/sofa/smoke/tests/actuator/reflection/ReflectionCacheEndpointUnrestrictedWebTests.java
@@ -28,12 +28,14 @@ import org.springframework.http.ResponseEntity;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Integration tests for {@code /actuator/reflection-cache}.
+ * Integration tests for unrestricted {@code /actuator/reflection-cache} access.
  *
  * @author xiaosiyuan
  */
-@SpringBootTest(classes = ActuatorSofaBootApplication.class, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = { "management.endpoints.web.exposure.include=reflection-cache" })
-public class ReflectionCacheEndpointWebTests {
+@SpringBootTest(classes = ActuatorSofaBootApplication.class, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = {
+                                                                                                                                       "management.endpoints.web.exposure.include=reflection-cache",
+                                                                                                                                       "management.endpoint.reflection-cache.access=unrestricted" })
+public class ReflectionCacheEndpointUnrestrictedWebTests {
 
     @Autowired
     private TestRestTemplate restTemplate;
@@ -42,18 +44,14 @@ public class ReflectionCacheEndpointWebTests {
     private ReflectionCache  reflectionCache;
 
     @Test
-    public void reflectionCacheEndpointShouldExposeStatsWithReadOnlyAccessByDefault()
-                                                                                     throws Exception {
+    public void reflectionCacheEndpointShouldClearWhenAccessIsUnrestricted() throws Exception {
         reflectionCache.forName(String.class.getName());
         reflectionCache.forName(String.class.getName());
 
-        ResponseEntity<String> response = restTemplate.getForEntity("/actuator/reflection-cache",
-            String.class);
+        ResponseEntity<String> response = restTemplate.postForEntity("/actuator/reflection-cache",
+            null, String.class);
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-        assertThat(response.getBody()).contains("\"enabled\":true").contains("\"classHitCount\":1")
-            .contains("\"classMissCount\":1").contains("\"classCacheSize\":1");
-
-        response = restTemplate.postForEntity("/actuator/reflection-cache", null, String.class);
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.METHOD_NOT_ALLOWED);
+        assertThat(response.getBody()).contains("\"totalHitCount\":0")
+            .contains("\"totalMissCount\":0").contains("\"classCacheSize\":0");
     }
 }

--- a/sofa-boot-tests/sofa-boot-smoke-tests/sofa-boot-smoke-tests-actuator/src/test/java/com/alipay/sofa/smoke/tests/actuator/reflection/ReflectionCacheEndpointWebTests.java
+++ b/sofa-boot-tests/sofa-boot-smoke-tests/sofa-boot-smoke-tests-actuator/src/test/java/com/alipay/sofa/smoke/tests/actuator/reflection/ReflectionCacheEndpointWebTests.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.smoke.tests.actuator.reflection;
+
+import com.alipay.sofa.boot.reflection.ReflectionCache;
+import com.alipay.sofa.smoke.tests.actuator.ActuatorSofaBootApplication;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@code /actuator/reflection-cache}.
+ *
+ * @author xiaosiyuan
+ * @since 4.5.0
+ */
+@SpringBootTest(classes = ActuatorSofaBootApplication.class, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = { "management.endpoints.web.exposure.include=reflection-cache" })
+public class ReflectionCacheEndpointWebTests {
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Autowired
+    private ReflectionCache  reflectionCache;
+
+    @Test
+    public void reflectionCacheEndpoint() throws Exception {
+        reflectionCache.forName(String.class.getName());
+        reflectionCache.forName(String.class.getName());
+
+        ResponseEntity<String> response = restTemplate.getForEntity("/actuator/reflection-cache",
+            String.class);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).contains("\"enabled\":true").contains("\"classHitCount\":1")
+            .contains("\"classMissCount\":1").contains("\"classCacheSize\":1");
+
+        response = restTemplate.postForEntity("/actuator/reflection-cache", null, String.class);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).contains("\"totalHitCount\":0")
+            .contains("\"totalMissCount\":0").contains("\"classCacheSize\":0");
+    }
+}

--- a/sofa-boot-tests/sofa-boot-smoke-tests/sofa-boot-smoke-tests-actuator/src/test/java/com/alipay/sofa/smoke/tests/actuator/reflection/ReflectionCacheEndpointWebTests.java
+++ b/sofa-boot-tests/sofa-boot-smoke-tests/sofa-boot-smoke-tests-actuator/src/test/java/com/alipay/sofa/smoke/tests/actuator/reflection/ReflectionCacheEndpointWebTests.java
@@ -31,7 +31,6 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Integration tests for {@code /actuator/reflection-cache}.
  *
  * @author xiaosiyuan
- * @since 4.5.0
  */
 @SpringBootTest(classes = ActuatorSofaBootApplication.class, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = { "management.endpoints.web.exposure.include=reflection-cache" })
 public class ReflectionCacheEndpointWebTests {


### PR DESCRIPTION
#1409 

### Changes

- introduce `ReflectionCache` to cache repeated reflection lookups
- support configuration via `sofa.boot.reflection.cache.enabled`
- apply reflection cache to `HealthIndicatorProcessor` and `DataSourceBeanPostProcessor`
- add `reflection-cache` actuator endpoint for stats and clear operation
- add related unit tests and smoke tests