### PR TITLE
[AI-8th]Add structured logging support to SOFABoot

### DIFF
--- a/sofa-boot-project/sofa-boot-actuator-autoconfigure/pom.xml
+++ b/sofa-boot-project/sofa-boot-actuator-autoconfigure/pom.xml
@@ -33,6 +33,11 @@
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-configuration-processor</artifactId>
             <optional>true</optional>
         </dependency>

--- a/sofa-boot-project/sofa-boot-actuator-autoconfigure/src/main/java/com/alipay/sofa/boot/actuator/autoconfigure/health/HealthProperties.java
+++ b/sofa-boot-project/sofa-boot-actuator-autoconfigure/src/main/java/com/alipay/sofa/boot/actuator/autoconfigure/health/HealthProperties.java
@@ -17,8 +17,10 @@
 package com.alipay.sofa.boot.actuator.autoconfigure.health;
 
 import com.alipay.sofa.boot.actuator.health.HealthCheckerConfig;
+import jakarta.validation.constraints.Positive;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
+import org.springframework.validation.annotation.Validated;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -33,6 +35,7 @@ import java.util.Map;
  * Created on 2020/5/18
  */
 @ConfigurationProperties("sofa.boot.actuator.health")
+@Validated
 public class HealthProperties {
 
     /**
@@ -54,6 +57,7 @@ public class HealthProperties {
     /**
      * Timeout duration of parallel health check, in milliseconds.
      */
+    @Positive(message = "并行健康检查超时时间必须大于 0")
     private long                                                                                parallelCheckTimeout         = 120 * 1000;
 
     /**
@@ -84,6 +88,7 @@ public class HealthProperties {
     /**
      * Global {@link com.alipay.sofa.boot.actuator.health.HealthChecker} health check timeout，in milliseconds.
      */
+    @Positive(message = "HealthChecker 全局超时时间必须大于 0")
     private int                                                                                 globalHealthCheckerTimeout   = 60 * 1000;
 
     /**
@@ -95,6 +100,7 @@ public class HealthProperties {
     /**
      * Global {@link org.springframework.boot.actuate.health.HealthIndicator} health check timeout，in milliseconds.
      */
+    @Positive(message = "HealthIndicator 全局超时时间必须大于 0")
     private int                                                                                 globalHealthIndicatorTimeout = 60 * 1000;
 
     /**

--- a/sofa-boot-project/sofa-boot-actuator-autoconfigure/src/test/java/com/alipay/sofa/boot/actuator/autoconfigure/health/ReadinessAutoConfigurationTests.java
+++ b/sofa-boot-project/sofa-boot-actuator-autoconfigure/src/test/java/com/alipay/sofa/boot/actuator/autoconfigure/health/ReadinessAutoConfigurationTests.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.condition.JRE;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.core.NestedExceptionUtils;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -145,6 +146,17 @@ public class ReadinessAutoConfigurationTests {
                     assertThat(context.getBean(HealthIndicatorProcessor.class).isParallelCheck()).isFalse();
                     assertThat(context.getBean(HealthIndicatorProcessor.class).getParallelCheckTimeout()).isEqualTo(30000);
                     assertThat(context.getBean(ReadinessCheckListener.READINESS_HEALTH_CHECK_EXECUTOR_BEAN_NAME, ThreadPoolExecutor.class).getMaximumPoolSize()).isEqualTo(1);
+                });
+    }
+
+    @Test
+    void invalidHealthPropertiesShouldFailFast() {
+        this.contextRunner
+                .withPropertyValues("sofa.boot.actuator.health.parallelCheckTimeout=0")
+                .run((context) -> {
+                    assertThat(context).hasFailed();
+                    assertThat(NestedExceptionUtils.getMostSpecificCause(context.getStartupFailure()).getMessage())
+                            .contains("并行健康检查超时时间必须大于 0");
                 });
     }
 

--- a/sofa-boot-project/sofa-boot-autoconfigure/pom.xml
+++ b/sofa-boot-project/sofa-boot-autoconfigure/pom.xml
@@ -28,6 +28,11 @@
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-configuration-processor</artifactId>
             <optional>true</optional>
         </dependency>

--- a/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/isle/SofaModuleProperties.java
+++ b/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/isle/SofaModuleProperties.java
@@ -16,7 +16,9 @@
  */
 package com.alipay.sofa.boot.autoconfigure.isle;
 
+import jakarta.validation.constraints.Positive;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -28,6 +30,7 @@ import java.util.List;
  * @author huzijie
  */
 @ConfigurationProperties("sofa.boot.isle")
+@Validated
 public class SofaModuleProperties {
 
     /**
@@ -78,16 +81,19 @@ public class SofaModuleProperties {
     /**
      * Thead pool size factor used in parallel sofa module application context refresh.
      */
+    @Positive(message = "模块并行刷新线程池倍率必须大于 0")
     private float        parallelRefreshPoolSizeFactor = 5.0f;
 
     /**
      * Timeout used in parallel sofa module application context refresh, in milliseconds.
      */
+    @Positive(message = "模块并行刷新超时时间必须大于 0")
     private long         parallelRefreshTimeout        = 60;
 
     /**
      * Monitor period used in parallel sofa module application context refresh, in milliseconds.
      */
+    @Positive(message = "模块并行刷新检查周期必须大于 0")
     private long         parallelRefreshCheckPeriod    = 30;
 
     public List<String> getActiveProfiles() {

--- a/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/rpc/SofaBootRpcProperties.java
+++ b/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/rpc/SofaBootRpcProperties.java
@@ -22,6 +22,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.EnvironmentAware;
 import org.springframework.core.env.Environment;
 import org.springframework.util.ObjectUtils;
+import org.springframework.validation.annotation.Validated;
 
 import java.util.HashMap;
 import java.util.List;
@@ -33,6 +34,8 @@ import java.util.Map;
  * @author khotyn
  */
 @ConfigurationProperties("sofa.boot.rpc")
+@Validated
+@ValidSofaBootRpcProperties
 public class SofaBootRpcProperties implements EnvironmentAware {
 
     public static final String  PREFIX     = "sofa.boot.rpc";

--- a/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/rpc/SofaBootRpcPropertiesValidator.java
+++ b/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/rpc/SofaBootRpcPropertiesValidator.java
@@ -1,0 +1,233 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.boot.autoconfigure.rpc;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import org.springframework.util.StringUtils;
+
+import java.math.BigDecimal;
+
+/**
+ * Validator for {@link SofaBootRpcProperties}.
+ *
+ * @author huzijie
+ */
+public class SofaBootRpcPropertiesValidator
+                                           implements
+                                           ConstraintValidator<ValidSofaBootRpcProperties, SofaBootRpcProperties> {
+
+    @Override
+    public boolean isValid(SofaBootRpcProperties value, ConstraintValidatorContext context) {
+        if (value == null) {
+            return true;
+        }
+        context.disableDefaultConstraintViolation();
+        boolean valid = true;
+
+        valid = validatePort(context, valid, "boltPort", value.getBoltPort(),
+            "Bolt 端口必须在 1024 到 65535 之间");
+        valid = validatePort(context, valid, "h2cPort", value.getH2cPort(),
+            "H2C 端口必须在 1024 到 65535 之间");
+        valid = validatePort(context, valid, "restPort", value.getRestPort(),
+            "REST 端口必须在 1024 到 65535 之间");
+        valid = validatePort(context, valid, "dubboPort", value.getDubboPort(),
+            "Dubbo 端口必须在 1024 到 65535 之间");
+        valid = validatePort(context, valid, "httpPort", value.getHttpPort(),
+            "HTTP 端口必须在 1024 到 65535 之间");
+        valid = validatePort(context, valid, "triplePort", value.getTriplePort(),
+            "Triple 端口必须在 1024 到 65535 之间");
+        valid = validatePort(context, valid, "virtualPort", value.getVirtualPort(),
+            "虚拟发布端口必须在 1024 到 65535 之间");
+
+        valid = validatePositiveInteger(context, valid, "boltThreadPoolCoreSize",
+            value.getBoltThreadPoolCoreSize(), "Bolt 线程池核心线程数必须大于 0");
+        valid = validatePositiveInteger(context, valid, "boltThreadPoolMaxSize",
+            value.getBoltThreadPoolMaxSize(), "Bolt 线程池最大线程数必须大于 0");
+        valid = validatePositiveInteger(context, valid, "boltThreadPoolQueueSize",
+            value.getBoltThreadPoolQueueSize(), "Bolt 线程池队列长度必须大于 0");
+        valid = validatePositiveInteger(context, valid, "boltAcceptsSize",
+            value.getBoltAcceptsSize(), "Bolt 允许建立的连接数必须大于 0");
+        valid = validatePositiveInteger(context, valid, "h2cThreadPoolCoreSize",
+            value.getH2cThreadPoolCoreSize(), "H2C 线程池核心线程数必须大于 0");
+        valid = validatePositiveInteger(context, valid, "h2cThreadPoolMaxSize",
+            value.getH2cThreadPoolMaxSize(), "H2C 线程池最大线程数必须大于 0");
+        valid = validatePositiveInteger(context, valid, "h2cThreadPoolQueueSize",
+            value.getH2cThreadPoolQueueSize(), "H2C 线程池队列长度必须大于 0");
+        valid = validatePositiveInteger(context, valid, "h2cAcceptsSize",
+            value.getH2cAcceptsSize(), "H2C 允许建立的连接数必须大于 0");
+        valid = validatePositiveInteger(context, valid, "restIoThreadSize",
+            value.getRestIoThreadSize(), "REST IO 线程数必须大于 0");
+        valid = validatePositiveInteger(context, valid, "restThreadPoolMaxSize",
+            value.getRestThreadPoolMaxSize(), "REST 线程池最大线程数必须大于 0");
+        valid = validatePositiveInteger(context, valid, "restMaxRequestSize",
+            value.getRestMaxRequestSize(), "REST 最大请求体大小必须大于 0");
+        valid = validatePositiveInteger(context, valid, "dubboIoThreadSize",
+            value.getDubboIoThreadSize(), "Dubbo IO 线程数必须大于 0");
+        valid = validatePositiveInteger(context, valid, "dubboThreadPoolMaxSize",
+            value.getDubboThreadPoolMaxSize(), "Dubbo 线程池最大线程数必须大于 0");
+        valid = validatePositiveInteger(context, valid, "dubboAcceptsSize",
+            value.getDubboAcceptsSize(), "Dubbo 允许建立的连接数必须大于 0");
+        valid = validatePositiveInteger(context, valid, "httpThreadPoolCoreSize",
+            value.getHttpThreadPoolCoreSize(), "HTTP 线程池核心线程数必须大于 0");
+        valid = validatePositiveInteger(context, valid, "httpThreadPoolMaxSize",
+            value.getHttpThreadPoolMaxSize(), "HTTP 线程池最大线程数必须大于 0");
+        valid = validatePositiveInteger(context, valid, "httpThreadPoolQueueSize",
+            value.getHttpThreadPoolQueueSize(), "HTTP 线程池队列长度必须大于 0");
+        valid = validatePositiveInteger(context, valid, "httpAcceptsSize",
+            value.getHttpAcceptsSize(), "HTTP 允许建立的连接数必须大于 0");
+        valid = validatePositiveInteger(context, valid, "tripleThreadPoolCoreSize",
+            value.getTripleThreadPoolCoreSize(), "Triple 线程池核心线程数必须大于 0");
+        valid = validatePositiveInteger(context, valid, "tripleThreadPoolMaxSize",
+            value.getTripleThreadPoolMaxSize(), "Triple 线程池最大线程数必须大于 0");
+        valid = validatePositiveInteger(context, valid, "tripleThreadPoolQueueSize",
+            value.getTripleThreadPoolQueueSize(), "Triple 线程池队列长度必须大于 0");
+        valid = validatePositiveInteger(context, valid, "tripleAcceptsSize",
+            value.getTripleAcceptsSize(), "Triple 允许建立的连接数必须大于 0");
+        valid = validatePositiveInteger(context, valid, "consumerRepeatedReferenceLimit",
+            value.getConsumerRepeatedReferenceLimit(), "重复引用限制必须大于 0");
+
+        valid = validateBooleanString(context, valid, "aftRegulationEffective",
+            value.getAftRegulationEffective(), "AFT 单机故障剔除开关必须为 true 或 false");
+        valid = validateBooleanString(context, valid, "aftDegradeEffective",
+            value.getAftDegradeEffective(), "AFT 降级开关必须为 true 或 false");
+        valid = validateBooleanString(context, valid, "restTelnet", value.getRestTelnet(),
+            "REST telnet 开关必须为 true 或 false");
+        valid = validateBooleanString(context, valid, "restDaemon", value.getRestDaemon(),
+            "REST daemon 开关必须为 true 或 false");
+
+        valid = validatePositiveInteger(context, valid, "aftTimeWindow", value.getAftTimeWindow(),
+            "AFT 时间窗口必须大于 0");
+        valid = validatePositiveInteger(context, valid, "aftLeastWindowCount",
+            value.getAftLeastWindowCount(), "AFT 最小调用次数必须大于 0");
+        valid = validatePositiveDecimal(context, valid, "aftLeastWindowExceptionRateMultiple",
+            value.getAftLeastWindowExceptionRateMultiple(), "AFT 最小异常率倍数必须大于 0");
+        valid = validateRange(context, valid, "aftDegradeLeastWeight",
+            value.getAftDegradeLeastWeight(), 0, 100, "降级最小权重必须在 0 到 100 之间");
+        valid = validatePositiveInteger(context, valid, "aftDegradeMaxIpCount",
+            value.getAftDegradeMaxIpCount(), "AFT 最大降级 IP 数必须大于 0");
+        valid = validateDecimalRange(context, valid, "aftWeightDegradeRate",
+            value.getAftWeightDegradeRate(), BigDecimal.ZERO, false, BigDecimal.ONE, true,
+            "降级速率必须大于 0 且不能大于 1");
+        valid = validatePositiveDecimal(context, valid, "aftWeightRecoverRate",
+            value.getAftWeightRecoverRate(), "恢复速率必须大于 0");
+
+        return valid;
+    }
+
+    private boolean validatePort(ConstraintValidatorContext context, boolean valid,
+                                 String fieldName, String rawValue, String message) {
+        return validateRange(context, valid, fieldName, rawValue, 1024, 65535, message);
+    }
+
+    private boolean validatePositiveInteger(ConstraintValidatorContext context, boolean valid,
+                                            String fieldName, String rawValue, String message) {
+        if (!StringUtils.hasText(rawValue)) {
+            return valid;
+        }
+        Integer parsedValue = parseInteger(rawValue);
+        if (parsedValue == null || parsedValue <= 0) {
+            addViolation(context, fieldName, message);
+            return false;
+        }
+        return valid;
+    }
+
+    private boolean validateRange(ConstraintValidatorContext context, boolean valid,
+                                  String fieldName, String rawValue, int min, int max,
+                                  String message) {
+        if (!StringUtils.hasText(rawValue)) {
+            return valid;
+        }
+        Integer parsedValue = parseInteger(rawValue);
+        if (parsedValue == null || parsedValue < min || parsedValue > max) {
+            addViolation(context, fieldName, message);
+            return false;
+        }
+        return valid;
+    }
+
+    private boolean validatePositiveDecimal(ConstraintValidatorContext context, boolean valid,
+                                            String fieldName, String rawValue, String message) {
+        if (!StringUtils.hasText(rawValue)) {
+            return valid;
+        }
+        BigDecimal parsedValue = parseDecimal(rawValue);
+        if (parsedValue == null || parsedValue.compareTo(BigDecimal.ZERO) <= 0) {
+            addViolation(context, fieldName, message);
+            return false;
+        }
+        return valid;
+    }
+
+    private boolean validateDecimalRange(ConstraintValidatorContext context, boolean valid,
+                                         String fieldName, String rawValue, BigDecimal min,
+                                         boolean minInclusive, BigDecimal max,
+                                         boolean maxInclusive, String message) {
+        if (!StringUtils.hasText(rawValue)) {
+            return valid;
+        }
+        BigDecimal parsedValue = parseDecimal(rawValue);
+        if (parsedValue == null) {
+            addViolation(context, fieldName, message);
+            return false;
+        }
+
+        boolean underMin = minInclusive ? parsedValue.compareTo(min) < 0 : parsedValue
+            .compareTo(min) <= 0;
+        boolean overMax = maxInclusive ? parsedValue.compareTo(max) > 0 : parsedValue
+            .compareTo(max) >= 0;
+        if (underMin || overMax) {
+            addViolation(context, fieldName, message);
+            return false;
+        }
+        return valid;
+    }
+
+    private boolean validateBooleanString(ConstraintValidatorContext context, boolean valid,
+                                          String fieldName, String rawValue, String message) {
+        if (!StringUtils.hasText(rawValue)) {
+            return valid;
+        }
+        if (!"true".equalsIgnoreCase(rawValue) && !"false".equalsIgnoreCase(rawValue)) {
+            addViolation(context, fieldName, message);
+            return false;
+        }
+        return valid;
+    }
+
+    private Integer parseInteger(String rawValue) {
+        try {
+            return Integer.valueOf(rawValue);
+        } catch (NumberFormatException ex) {
+            return null;
+        }
+    }
+
+    private BigDecimal parseDecimal(String rawValue) {
+        try {
+            return new BigDecimal(rawValue);
+        } catch (NumberFormatException ex) {
+            return null;
+        }
+    }
+
+    private void addViolation(ConstraintValidatorContext context, String fieldName, String message) {
+        context.buildConstraintViolationWithTemplate(message).addPropertyNode(fieldName)
+            .addConstraintViolation();
+    }
+}

--- a/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/rpc/ValidSofaBootRpcProperties.java
+++ b/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/rpc/ValidSofaBootRpcProperties.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.boot.autoconfigure.rpc;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Class-level constraint for {@link SofaBootRpcProperties}.
+ *
+ * @author huzijie
+ */
+@Documented
+@Constraint(validatedBy = SofaBootRpcPropertiesValidator.class)
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidSofaBootRpcProperties {
+
+    String message() default "SOFA RPC 配置不合法";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/runtime/SofaRuntimeProperties.java
+++ b/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/runtime/SofaRuntimeProperties.java
@@ -17,7 +17,10 @@
 package com.alipay.sofa.boot.autoconfigure.runtime;
 
 import com.alipay.sofa.boot.constant.SofaBootConstants;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.PositiveOrZero;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -29,6 +32,7 @@ import java.util.List;
  * @author huzijie
  */
 @ConfigurationProperties("sofa.boot.runtime")
+@Validated
 public class SofaRuntimeProperties {
 
     /**
@@ -80,11 +84,13 @@ public class SofaRuntimeProperties {
     /**
      * Custom async init executor core size.
      */
+    @PositiveOrZero(message = "异步初始化线程池核心线程数不能小于 0")
     private int          asyncInitExecutorCoreSize       = SofaBootConstants.CPU_CORE + 1;
 
     /**
      * Custom async init executor max size.
      */
+    @PositiveOrZero(message = "异步初始化线程池最大线程数不能小于 0")
     private int          asyncInitExecutorMaxSize        = SofaBootConstants.CPU_CORE + 1;
 
     /**
@@ -199,5 +205,10 @@ public class SofaRuntimeProperties {
 
     public void setServiceCanBeDuplicate(boolean serviceCanBeDuplicate) {
         this.serviceCanBeDuplicate = serviceCanBeDuplicate;
+    }
+
+    @AssertTrue(message = "异步初始化线程池最大线程数不能小于核心线程数")
+    public boolean isAsyncInitExecutorPoolSizeValid() {
+        return asyncInitExecutorMaxSize >= asyncInitExecutorCoreSize;
     }
 }

--- a/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/tracer/SofaTracerProperties.java
+++ b/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/tracer/SofaTracerProperties.java
@@ -19,7 +19,11 @@ package com.alipay.sofa.boot.autoconfigure.tracer;
 import com.alipay.common.tracer.core.appender.file.TimedRollingFileAppender;
 import com.alipay.common.tracer.core.configuration.SofaTracerConfiguration;
 import com.alipay.common.tracer.core.reporter.stat.manager.SofaTracerStatisticReporterManager;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Pattern;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -34,11 +38,13 @@ import static com.alipay.common.tracer.core.configuration.SofaTracerConfiguratio
  * @since 2018/04/30
  */
 @ConfigurationProperties("sofa.boot.tracer")
+@Validated
 public class SofaTracerProperties {
 
     /**
      * Disable digest log.
      */
+    @Pattern(regexp = "^(?i:true|false)$", message = "disableDigestLog 必须为 true 或 false")
     private String              disableDigestLog          = "false";
 
     /**
@@ -54,17 +60,20 @@ public class SofaTracerProperties {
     /**
      * Tracer's global log retention days configuration.
      */
+    @Pattern(regexp = "^\\d+$", message = "日志保留天数必须为非负整数")
     private String              tracerGlobalLogReserveDay = String.valueOf(DEFAULT_LOG_RESERVE_DAY);
 
     /**
      * The interval for printing the stat log.
      */
+    @Pattern(regexp = "^\\d+$", message = "统计日志打印间隔必须为非负整数")
     private String              statLogInterval           = String
                                                               .valueOf(SofaTracerStatisticReporterManager.DEFAULT_CYCLE_SECONDS);
 
     /**
      * Threshold, the length of the service transparent field
      */
+    @Pattern(regexp = "^\\d+$", message = "透传字段长度阈值必须为非负整数")
     private String              baggageMaxLength          = String
                                                               .valueOf(SofaTracerConfiguration.PEN_ATTRS_LENGTH_TRESHOLD);
 
@@ -76,6 +85,8 @@ public class SofaTracerProperties {
     /**
      * Sampling policy percentage.
      */
+    @DecimalMin(value = "0.0", message = "采样率不能小于 0")
+    @DecimalMax(value = "100.0", message = "采样率不能大于 100")
     private float               samplerPercentage         = 100;
 
     /**

--- a/sofa-boot-project/sofa-boot-autoconfigure/src/test/java/com/alipay/sofa/boot/autoconfigure/isle/SofaModuleAutoConfigurationTests.java
+++ b/sofa-boot-project/sofa-boot-autoconfigure/src/test/java/com/alipay/sofa/boot/autoconfigure/isle/SofaModuleAutoConfigurationTests.java
@@ -36,6 +36,7 @@ import org.junit.jupiter.api.condition.JRE;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.core.NestedExceptionUtils;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -151,6 +152,17 @@ public class SofaModuleAutoConfigurationTests {
                     assertThat(threadPoolExecutor.getCorePoolSize()).isEqualTo(SofaBootConstants.CPU_CORE * 2);
                     assertThat(threadPoolExecutor.getConfig().getTaskTimeout()).isEqualTo(10);
                     assertThat(threadPoolExecutor.getConfig().getPeriod()).isEqualTo(20);
+                });
+    }
+
+    @Test
+    void invalidParallelRefreshConfigShouldFailFast() {
+        this.contextRunner
+                .withPropertyValues("sofa.boot.isle.parallelRefreshPoolSizeFactor=0")
+                .run((context) -> {
+                    assertThat(context).hasFailed();
+                    assertThat(NestedExceptionUtils.getMostSpecificCause(context.getStartupFailure()).getMessage())
+                            .contains("模块并行刷新线程池倍率必须大于 0");
                 });
     }
 

--- a/sofa-boot-project/sofa-boot-autoconfigure/src/test/java/com/alipay/sofa/boot/autoconfigure/rpc/SofaBootRpcPropertiesValidatorTests.java
+++ b/sofa-boot-project/sofa-boot-autoconfigure/src/test/java/com/alipay/sofa/boot/autoconfigure/rpc/SofaBootRpcPropertiesValidatorTests.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.boot.autoconfigure.rpc;
+
+import jakarta.validation.ConstraintValidatorContext;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.core.env.StandardEnvironment;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+/**
+ * Tests for {@link SofaBootRpcPropertiesValidator}.
+ */
+public class SofaBootRpcPropertiesValidatorTests {
+
+    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+    @Test
+    void shouldAcceptNullProperties() {
+        SofaBootRpcPropertiesValidator propertiesValidator = new SofaBootRpcPropertiesValidator();
+        ConstraintValidatorContext context = Mockito.mock(ConstraintValidatorContext.class);
+
+        assertThat(propertiesValidator.isValid(null, context)).isTrue();
+        verifyNoInteractions(context);
+    }
+
+    @Test
+    void shouldAcceptValidProperties() {
+        Set<ConstraintViolation<SofaBootRpcProperties>> violations = this.validator
+            .validate(createValidProperties());
+
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    void shouldIgnoreBlankValues() {
+        SofaBootRpcProperties properties = createValidProperties();
+        properties.setBoltPort(" ");
+        properties.setBoltThreadPoolCoreSize("");
+        properties.setAftRegulationEffective(" ");
+        properties.setAftWeightRecoverRate("");
+
+        Set<ConstraintViolation<SofaBootRpcProperties>> violations = this.validator
+            .validate(properties);
+
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    void shouldRejectOutOfRangeAndInvalidBooleanValues() {
+        SofaBootRpcProperties properties = createValidProperties();
+        properties.setBoltPort("80");
+        properties.setBoltThreadPoolCoreSize("0");
+        properties.setAftRegulationEffective("maybe");
+        properties.setAftLeastWindowExceptionRateMultiple("-1");
+        properties.setAftDegradeLeastWeight("101");
+        properties.setAftWeightDegradeRate("0");
+
+        Set<String> propertyNames = propertyNames(this.validator.validate(properties));
+
+        assertThat(propertyNames).contains("boltPort", "boltThreadPoolCoreSize",
+            "aftRegulationEffective", "aftLeastWindowExceptionRateMultiple",
+            "aftDegradeLeastWeight", "aftWeightDegradeRate");
+    }
+
+    @Test
+    void shouldRejectNonNumericValues() {
+        SofaBootRpcProperties properties = createValidProperties();
+        properties.setH2cPort("port");
+        properties.setDubboThreadPoolMaxSize("many");
+        properties.setAftWeightRecoverRate("fast");
+
+        Set<String> propertyNames = propertyNames(this.validator.validate(properties));
+
+        assertThat(propertyNames).contains("h2cPort", "dubboThreadPoolMaxSize",
+            "aftWeightRecoverRate");
+    }
+
+    private Set<String> propertyNames(Set<ConstraintViolation<SofaBootRpcProperties>> violations) {
+        return violations.stream().map((violation) -> violation.getPropertyPath().toString())
+            .collect(Collectors.toSet());
+    }
+
+    private SofaBootRpcProperties createValidProperties() {
+        SofaBootRpcProperties properties = new SofaBootRpcProperties();
+        properties.setEnvironment(new StandardEnvironment());
+        properties.setBoltPort("12200");
+        properties.setH2cPort("12201");
+        properties.setRestPort("12202");
+        properties.setDubboPort("12203");
+        properties.setHttpPort("12204");
+        properties.setTriplePort("12205");
+        properties.setVirtualPort("12206");
+
+        properties.setBoltThreadPoolCoreSize("10");
+        properties.setBoltThreadPoolMaxSize("20");
+        properties.setBoltThreadPoolQueueSize("100");
+        properties.setBoltAcceptsSize("500");
+        properties.setH2cThreadPoolCoreSize("10");
+        properties.setH2cThreadPoolMaxSize("20");
+        properties.setH2cThreadPoolQueueSize("100");
+        properties.setH2cAcceptsSize("500");
+        properties.setRestIoThreadSize("8");
+        properties.setRestThreadPoolMaxSize("20");
+        properties.setRestMaxRequestSize("1024");
+        properties.setDubboIoThreadSize("8");
+        properties.setDubboThreadPoolMaxSize("20");
+        properties.setDubboAcceptsSize("500");
+        properties.setHttpThreadPoolCoreSize("10");
+        properties.setHttpThreadPoolMaxSize("20");
+        properties.setHttpThreadPoolQueueSize("100");
+        properties.setHttpAcceptsSize("500");
+        properties.setTripleThreadPoolCoreSize("10");
+        properties.setTripleThreadPoolMaxSize("20");
+        properties.setTripleThreadPoolQueueSize("100");
+        properties.setTripleAcceptsSize("500");
+        properties.setConsumerRepeatedReferenceLimit("10");
+
+        properties.setAftRegulationEffective("true");
+        properties.setAftDegradeEffective("false");
+        properties.setRestTelnet("false");
+        properties.setRestDaemon("true");
+        properties.setAftTimeWindow("10");
+        properties.setAftLeastWindowCount("20");
+        properties.setAftLeastWindowExceptionRateMultiple("1.5");
+        properties.setAftDegradeLeastWeight("20");
+        properties.setAftDegradeMaxIpCount("5");
+        properties.setAftWeightDegradeRate("0.5");
+        properties.setAftWeightRecoverRate("1.5");
+        return properties;
+    }
+}

--- a/sofa-boot-project/sofa-boot-autoconfigure/src/test/java/com/alipay/sofa/boot/autoconfigure/rpc/SofaRpcAutoConfigurationTests.java
+++ b/sofa-boot-project/sofa-boot-autoconfigure/src/test/java/com/alipay/sofa/boot/autoconfigure/rpc/SofaRpcAutoConfigurationTests.java
@@ -46,6 +46,7 @@ import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.NestedExceptionUtils;
 
 import javax.ws.rs.client.ClientRequestFilter;
 import javax.ws.rs.client.ClientResponseFilter;
@@ -212,6 +213,18 @@ public class SofaRpcAutoConfigurationTests {
                     assertThat(faultToleranceConfig.getWeightRecoverRate()).isEqualTo(3.0);
                     assertThat(faultToleranceConfig.getDegradeLeastWeight()).isEqualTo(2);
                     assertThat(faultToleranceConfig.getDegradeMaxIpCount()).isEqualTo(3);
+                });
+    }
+
+    @Test
+    void invalidRpcPropertiesShouldFailFast() {
+        this.contextRunner.withPropertyValues("sofa.boot.rpc.boltPort=80",
+                        "sofa.boot.rpc.aftDegradeLeastWeight=-10")
+                .run(context -> {
+                    assertThat(context).hasFailed();
+                    assertThat(NestedExceptionUtils.getMostSpecificCause(context.getStartupFailure()).getMessage())
+                            .contains("Bolt 端口必须在 1024 到 65535 之间")
+                            .contains("降级最小权重必须在 0 到 100 之间");
                 });
     }
 

--- a/sofa-boot-project/sofa-boot-autoconfigure/src/test/java/com/alipay/sofa/boot/autoconfigure/runtime/SofaRuntimeAutoConfigurationTests.java
+++ b/sofa-boot-project/sofa-boot-autoconfigure/src/test/java/com/alipay/sofa/boot/autoconfigure/runtime/SofaRuntimeAutoConfigurationTests.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.condition.JRE;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.core.NestedExceptionUtils;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -127,6 +128,18 @@ public class SofaRuntimeAutoConfigurationTests {
                     assertThat(threadPoolExecutor).isInstanceOf(ThreadPoolExecutor.class);
                     assertThat(((ThreadPoolExecutor) threadPoolExecutor).getCorePoolSize()).isEqualTo(10);
                     assertThat(((ThreadPoolExecutor) threadPoolExecutor).getMaximumPoolSize()).isEqualTo(10);
+                });
+    }
+
+    @Test
+    public void invalidAsyncInitExecutorConfigShouldFailFast() {
+        this.contextRunner
+                .withPropertyValues("sofa.boot.runtime.asyncInitExecutorCoreSize=10")
+                .withPropertyValues("sofa.boot.runtime.asyncInitExecutorMaxSize=5")
+                .run((context) -> {
+                    assertThat(context).hasFailed();
+                    assertThat(NestedExceptionUtils.getMostSpecificCause(context.getStartupFailure()).getMessage())
+                            .contains("异步初始化线程池最大线程数不能小于核心线程数");
                 });
     }
 

--- a/sofa-boot-project/sofa-boot-autoconfigure/src/test/java/com/alipay/sofa/boot/autoconfigure/tracer/SofaTracerAutoConfigurationTests.java
+++ b/sofa-boot-project/sofa-boot-autoconfigure/src/test/java/com/alipay/sofa/boot/autoconfigure/tracer/SofaTracerAutoConfigurationTests.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.core.NestedExceptionUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -57,6 +58,17 @@ public class SofaTracerAutoConfigurationTests {
     public void withoutSpanReportListenerHolder() {
         this.contextRunner
                 .run((context) -> assertThat(context.getBean("sofaTracerSpanReportListener").toString()).isEqualTo("null"));
+    }
+
+    @Test
+    public void invalidTracerPropertiesShouldFailFast() {
+        this.contextRunner
+                .withPropertyValues("sofa.boot.tracer.samplerPercentage=101")
+                .run((context) -> {
+                    assertThat(context).hasFailed();
+                    assertThat(NestedExceptionUtils.getMostSpecificCause(context.getStartupFailure()).getMessage())
+                            .contains("采样率不能大于 100");
+                });
     }
 
     static class SampleSpanReportListener implements SpanReportListener {

--- a/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/main/resources/com/alipay/sofa/rpc/boot/log/logback/log-conf.xml
+++ b/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/main/resources/com/alipay/sofa/rpc/boot/log/logback/log-conf.xml
@@ -20,7 +20,8 @@
             <!--日志文件保留天数-->
             <MaxHistory>30</MaxHistory>
         </rollingPolicy>
-        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+        <encoder class="com.alipay.sofa.boot.logging.logback.SofaStructuredLogEncoder">
+            <format>${FILE_LOG_STRUCTURED_FORMAT}</format>
             <pattern>%d %-5p %-32t - %m%n</pattern>
             <!-- 编码 -->
             <charset>${file.encoding}</charset>
@@ -42,7 +43,8 @@
             <!--日志文件保留天数-->
             <MaxHistory>30</MaxHistory>
         </rollingPolicy>
-        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+        <encoder class="com.alipay.sofa.boot.logging.logback.SofaStructuredLogEncoder">
+            <format>${FILE_LOG_STRUCTURED_FORMAT}</format>
             <pattern>%d %-5p %-32t - %m%n</pattern>
             <!-- 编码 -->
             <charset>${file.encoding}</charset>
@@ -65,7 +67,8 @@
             <!--日志文件保留天数-->
             <MaxHistory>30</MaxHistory>
         </rollingPolicy>
-        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+        <encoder class="com.alipay.sofa.boot.logging.logback.SofaStructuredLogEncoder">
+            <format>${FILE_LOG_STRUCTURED_FORMAT}</format>
             <pattern>%d %-5p %-32t %c{2} - %m%n</pattern>
             <!-- 编码 -->
             <charset>${file.encoding}</charset>
@@ -87,7 +90,8 @@
             <!--日志文件保留天数-->
             <MaxHistory>30</MaxHistory>
         </rollingPolicy>
-        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+        <encoder class="com.alipay.sofa.boot.logging.logback.SofaStructuredLogEncoder">
+            <format>${FILE_LOG_STRUCTURED_FORMAT}</format>
             <pattern>%d %-5p %-32t %c{2} - %m%n</pattern>
             <!-- 编码 -->
             <charset>${file.encoding}</charset>
@@ -109,7 +113,8 @@
             <!--日志文件保留天数-->
             <MaxHistory>30</MaxHistory>
         </rollingPolicy>
-        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+        <encoder class="com.alipay.sofa.boot.logging.logback.SofaStructuredLogEncoder">
+            <format>${FILE_LOG_STRUCTURED_FORMAT}</format>
             <pattern>%d %-5p %-32t %c{2} - %m%n</pattern>
             <!-- 编码 -->
             <charset>${file.encoding}</charset>

--- a/sofa-boot-project/sofa-boot/pom.xml
+++ b/sofa-boot-project/sofa-boot/pom.xml
@@ -30,6 +30,12 @@
         </dependency>
 
         <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-context</artifactId>
             <optional>true</optional>
@@ -42,8 +48,8 @@
         </dependency>
 
         <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
+            <groupId>com.alipay.sofa</groupId>
+            <artifactId>tracer-core</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/sofa-boot-project/sofa-boot/src/main/java/com/alipay/sofa/boot/logging/LogEnvironmentPostProcessor.java
+++ b/sofa-boot-project/sofa-boot/src/main/java/com/alipay/sofa/boot/logging/LogEnvironmentPostProcessor.java
@@ -42,12 +42,28 @@ import java.util.Map;
  */
 public class LogEnvironmentPostProcessor implements EnvironmentPostProcessor, Ordered {
 
-    public static final int    ORDER                            = ConfigDataEnvironmentPostProcessor.ORDER + 1;
+    public static final int    ORDER                              = ConfigDataEnvironmentPostProcessor.ORDER + 1;
+
+    static final String        FILE_LOG_STRUCTURED_FORMAT         = "FILE_LOG_STRUCTURED_FORMAT";
+
+    static final String        CONSOLE_LOG_STRUCTURED_FORMAT      = "CONSOLE_LOG_STRUCTURED_FORMAT";
+
+    static final String        FILE_STRUCTURED_FORMAT_PROPERTY    = "logging.structured.format.file";
+
+    static final String        CONSOLE_STRUCTURED_FORMAT_PROPERTY = "logging.structured.format.console";
+
+    static final String        STRUCTURED_LOGGING_PREFIX          = "logging.structured.";
+
+    static final String        TRACER_STRUCTURED_PREFIX           = "logging.sofa.tracer.";
+
+    static final String        APPLICATION_NAME_PROPERTY          = "spring.application.name";
+
+    static final String        APPLICATION_VERSION_PROPERTY       = "spring.application.version";
 
     /**
      * support use config to disable sofa common thread pool monitor.
      */
-    public static final String SOFA_THREAD_POOL_MONITOR_DISABLE = "sofa.boot.tools.threadpool.monitor.disable";
+    public static final String SOFA_THREAD_POOL_MONITOR_DISABLE   = "sofa.boot.tools.threadpool.monitor.disable";
 
     @Override
     public void postProcessEnvironment(ConfigurableEnvironment environment,
@@ -71,6 +87,10 @@ public class LogEnvironmentPostProcessor implements EnvironmentPostProcessor, Or
             context);
         loadLogConfiguration(Constants.LOG_ENCODING_PROP_KEY,
             environment.getProperty(Constants.LOG_ENCODING_PROP_KEY), context);
+        loadLogConfiguration(FILE_LOG_STRUCTURED_FORMAT,
+            environment.getProperty(FILE_STRUCTURED_FORMAT_PROPERTY, ""), context);
+        loadLogConfiguration(CONSOLE_LOG_STRUCTURED_FORMAT,
+            environment.getProperty(CONSOLE_STRUCTURED_FORMAT_PROPERTY, ""), context);
         // Don't delete this!
         // Some old SOFA SDKs rely on JVM system properties to determine log configurations.
         LogEnvUtils.keepCompatible(context, true);
@@ -83,6 +103,9 @@ public class LogEnvironmentPostProcessor implements EnvironmentPostProcessor, Or
             if (propertySource instanceof EnumerablePropertySource) {
                 for (String key : ((EnumerablePropertySource) propertySource).getPropertyNames()) {
                     if (LogEnvUtils.isSofaCommonLoggingConfig(key)) {
+                        CommonLoggingConfigurations.loadExternalConfiguration(key,
+                            environment.getProperty(key));
+                    } else if (isStructuredLoggingConfig(key) || isApplicationMetadata(key)) {
                         CommonLoggingConfigurations.loadExternalConfiguration(key,
                             environment.getProperty(key));
                     }
@@ -108,9 +131,18 @@ public class LogEnvironmentPostProcessor implements EnvironmentPostProcessor, Or
     }
 
     private void loadLogConfiguration(String key, String value, Map<String, String> context) {
-        if (StringUtils.hasText(value)) {
+        if (value != null) {
             context.put(key, value);
         }
+    }
+
+    private boolean isStructuredLoggingConfig(String key) {
+        return key.startsWith(STRUCTURED_LOGGING_PREFIX)
+               || key.startsWith(TRACER_STRUCTURED_PREFIX);
+    }
+
+    private boolean isApplicationMetadata(String key) {
+        return APPLICATION_NAME_PROPERTY.equals(key) || APPLICATION_VERSION_PROPERTY.equals(key);
     }
 
     private void initSofaCommonThread(ConfigurableEnvironment environment) {

--- a/sofa-boot-project/sofa-boot/src/main/java/com/alipay/sofa/boot/logging/LogEnvironmentPostProcessor.java
+++ b/sofa-boot-project/sofa-boot/src/main/java/com/alipay/sofa/boot/logging/LogEnvironmentPostProcessor.java
@@ -42,28 +42,24 @@ import java.util.Map;
  */
 public class LogEnvironmentPostProcessor implements EnvironmentPostProcessor, Ordered {
 
-    public static final int    ORDER                              = ConfigDataEnvironmentPostProcessor.ORDER + 1;
+    public static final int    ORDER                            = ConfigDataEnvironmentPostProcessor.ORDER + 1;
 
-    static final String        FILE_LOG_STRUCTURED_FORMAT         = "FILE_LOG_STRUCTURED_FORMAT";
+    static final String        FILE_LOG_STRUCTURED_FORMAT       = "FILE_LOG_STRUCTURED_FORMAT";
 
-    static final String        CONSOLE_LOG_STRUCTURED_FORMAT      = "CONSOLE_LOG_STRUCTURED_FORMAT";
+    static final String        FILE_STRUCTURED_FORMAT_PROPERTY  = "logging.structured.format.file";
 
-    static final String        FILE_STRUCTURED_FORMAT_PROPERTY    = "logging.structured.format.file";
+    static final String        STRUCTURED_LOGGING_PREFIX        = "logging.structured.";
 
-    static final String        CONSOLE_STRUCTURED_FORMAT_PROPERTY = "logging.structured.format.console";
+    static final String        TRACER_STRUCTURED_PREFIX         = "logging.sofa.tracer.";
 
-    static final String        STRUCTURED_LOGGING_PREFIX          = "logging.structured.";
+    static final String        APPLICATION_NAME_PROPERTY        = "spring.application.name";
 
-    static final String        TRACER_STRUCTURED_PREFIX           = "logging.sofa.tracer.";
-
-    static final String        APPLICATION_NAME_PROPERTY          = "spring.application.name";
-
-    static final String        APPLICATION_VERSION_PROPERTY       = "spring.application.version";
+    static final String        APPLICATION_VERSION_PROPERTY     = "spring.application.version";
 
     /**
      * support use config to disable sofa common thread pool monitor.
      */
-    public static final String SOFA_THREAD_POOL_MONITOR_DISABLE   = "sofa.boot.tools.threadpool.monitor.disable";
+    public static final String SOFA_THREAD_POOL_MONITOR_DISABLE = "sofa.boot.tools.threadpool.monitor.disable";
 
     @Override
     public void postProcessEnvironment(ConfigurableEnvironment environment,
@@ -89,8 +85,6 @@ public class LogEnvironmentPostProcessor implements EnvironmentPostProcessor, Or
             environment.getProperty(Constants.LOG_ENCODING_PROP_KEY), context);
         loadLogConfiguration(FILE_LOG_STRUCTURED_FORMAT,
             environment.getProperty(FILE_STRUCTURED_FORMAT_PROPERTY, ""), context);
-        loadLogConfiguration(CONSOLE_LOG_STRUCTURED_FORMAT,
-            environment.getProperty(CONSOLE_STRUCTURED_FORMAT_PROPERTY, ""), context);
         // Don't delete this!
         // Some old SOFA SDKs rely on JVM system properties to determine log configurations.
         LogEnvUtils.keepCompatible(context, true);

--- a/sofa-boot-project/sofa-boot/src/main/java/com/alipay/sofa/boot/logging/logback/SofaStructuredLogEncoder.java
+++ b/sofa-boot-project/sofa-boot/src/main/java/com/alipay/sofa/boot/logging/logback/SofaStructuredLogEncoder.java
@@ -51,7 +51,7 @@ import java.util.Map;
  * switches to Spring Boot's structured logging formatters when a structured format is
  * configured for SOFA logger spaces.
  *
- * @author OpenAI
+ * @author Alan
  * @since 4.6.0
  */
 public class SofaStructuredLogEncoder extends EncoderBase<ILoggingEvent> {

--- a/sofa-boot-project/sofa-boot/src/main/java/com/alipay/sofa/boot/logging/logback/SofaStructuredLogEncoder.java
+++ b/sofa-boot-project/sofa-boot/src/main/java/com/alipay/sofa/boot/logging/logback/SofaStructuredLogEncoder.java
@@ -1,0 +1,412 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.boot.logging.logback;
+
+import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
+import ch.qos.logback.classic.pattern.ThrowableProxyConverter;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.Context;
+import ch.qos.logback.core.encoder.EncoderBase;
+import org.springframework.boot.logging.StackTracePrinter;
+import org.springframework.boot.logging.structured.CommonStructuredLogFormat;
+import org.springframework.boot.logging.structured.ContextPairs;
+import org.springframework.boot.logging.structured.StructuredLogFormatter;
+import org.springframework.boot.logging.structured.StructuredLogFormatterFactory;
+import org.springframework.boot.logging.structured.StructuredLoggingJsonMembersCustomizer;
+import org.springframework.boot.util.Instantiator;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.env.StandardEnvironment;
+import org.springframework.util.Assert;
+import org.springframework.util.ClassUtils;
+import org.springframework.util.ReflectionUtils;
+import org.springframework.util.StringUtils;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Logback encoder that keeps the existing pattern output as the fallback behavior and
+ * switches to Spring Boot's structured logging formatters when a structured format is
+ * configured for SOFA logger spaces.
+ *
+ * @author OpenAI
+ * @since 4.6.0
+ */
+public class SofaStructuredLogEncoder extends EncoderBase<ILoggingEvent> {
+
+    private final ThrowableProxyConverter         throwableProxyConverter = new ThrowableProxyConverter();
+
+    private Charset                               charset                 = StandardCharsets.UTF_8;
+
+    private String                                format;
+
+    private String                                pattern;
+
+    private StructuredLogFormatter<ILoggingEvent> formatter;
+
+    private PatternLayoutEncoder                  patternEncoder;
+
+    public void setFormat(String format) {
+        this.format = format;
+    }
+
+    public void setPattern(String pattern) {
+        this.pattern = pattern;
+    }
+
+    public void setCharset(Charset charset) {
+        this.charset = charset;
+    }
+
+    @Override
+    public void start() {
+        this.throwableProxyConverter.setContext(getContext());
+        this.throwableProxyConverter.start();
+
+        String configuredFormat = resolveFormat(this.format);
+        if (StringUtils.hasText(configuredFormat)) {
+            this.formatter = createFormatter(configuredFormat);
+        } else {
+            this.patternEncoder = createPatternEncoder();
+        }
+        super.start();
+    }
+
+    @Override
+    public void stop() {
+        this.throwableProxyConverter.stop();
+        if (this.patternEncoder != null) {
+            this.patternEncoder.stop();
+        }
+        super.stop();
+    }
+
+    @Override
+    public byte[] headerBytes() {
+        return null;
+    }
+
+    @Override
+    public byte[] encode(ILoggingEvent event) {
+        Charset targetCharset = (this.charset != null) ? this.charset : StandardCharsets.UTF_8;
+        if (this.formatter != null) {
+            return this.formatter.formatAsBytes(event, targetCharset);
+        }
+        return this.patternEncoder.encode(event);
+    }
+
+    @Override
+    public byte[] footerBytes() {
+        return null;
+    }
+
+    private PatternLayoutEncoder createPatternEncoder() {
+        Assert.state(StringUtils.hasText(this.pattern), "Pattern has not been set");
+        PatternLayoutEncoder encoder = new PatternLayoutEncoder();
+        encoder.setContext(getContext());
+        encoder.setPattern(this.pattern);
+        encoder.setCharset(this.charset);
+        encoder.start();
+        return encoder;
+    }
+
+    private StructuredLogFormatter<ILoggingEvent> createFormatter(String configuredFormat) {
+        Environment environment = createEnvironment();
+        StructuredLogFormatterFactory<ILoggingEvent> factory = new StructuredLogFormatterFactory<>(
+            ILoggingEvent.class, environment, this::addAvailableParameters,
+            (commonFormats) -> addCommonFormatters(commonFormats, environment));
+        return factory.get(configuredFormat);
+    }
+
+    private Environment createEnvironment() {
+        StandardEnvironment environment = new StandardEnvironment();
+        Map<String, Object> properties = new LinkedHashMap<>();
+        Context context = getContext();
+        if (context != null) {
+            properties.putAll(context.getCopyOfPropertyMap());
+        }
+        if (StringUtils.hasText(resolveFormat(this.format))) {
+            properties.putIfAbsent("logging.structured.format.file", resolveFormat(this.format));
+        }
+        environment.getPropertySources().addFirst(
+            new MapPropertySource("sofa-structured-logging", properties));
+        return environment;
+    }
+
+    private void addAvailableParameters(Instantiator.AvailableParameters parameters) {
+        parameters.add(ThrowableProxyConverter.class, this.throwableProxyConverter);
+    }
+
+    private void addCommonFormatters(
+                                   StructuredLogFormatterFactory.CommonFormatters<ILoggingEvent> commonFormats,
+                                   Environment environment) {
+        commonFormats.add(CommonStructuredLogFormat.ELASTIC_COMMON_SCHEMA,
+            (instantiator) -> instantiateEcsFormatter(instantiator, environment));
+        commonFormats.add(CommonStructuredLogFormat.LOGSTASH,
+            (instantiator) -> instantiateLogstashFormatter(instantiator, environment));
+    }
+
+    @SuppressWarnings("unchecked")
+    private StructuredLogFormatter<ILoggingEvent> instantiateEcsFormatter(Instantiator<?> instantiator,
+                                                                          Environment environment) {
+        try {
+            Class<?> formatterClass = ClassUtils
+                .forName(
+                    "org.springframework.boot.logging.logback.ElasticCommonSchemaStructuredLogFormatter",
+                    null);
+            Constructor<?> constructor = formatterClass.getDeclaredConstructor(Environment.class,
+                StackTracePrinter.class, ContextPairs.class, ThrowableProxyConverter.class,
+                StructuredLoggingJsonMembersCustomizer.Builder.class);
+            ReflectionUtils.makeAccessible(constructor);
+            return (StructuredLogFormatter<ILoggingEvent>) constructor.newInstance(
+                instantiator.getArg(Environment.class),
+                instantiator.getArg(StackTracePrinter.class),
+                instantiator.getArg(ContextPairs.class),
+                instantiator.getArg(ThrowableProxyConverter.class),
+                new CompositeJsonMembersCustomizerBuilder<>(instantiator
+                    .getArg(StructuredLoggingJsonMembersCustomizer.Builder.class),
+                    createTraceContextCustomizer(environment)));
+        } catch (ReflectiveOperationException ex) {
+            throw new IllegalStateException("Failed to create ECS structured log formatter", ex);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private StructuredLogFormatter<ILoggingEvent> instantiateLogstashFormatter(Instantiator<?> instantiator,
+                                                                               Environment environment) {
+        try {
+            Class<?> formatterClass = ClassUtils.forName(
+                "org.springframework.boot.logging.logback.LogstashStructuredLogFormatter", null);
+            Constructor<?> constructor = formatterClass.getDeclaredConstructor(
+                StackTracePrinter.class, ContextPairs.class, ThrowableProxyConverter.class,
+                StructuredLoggingJsonMembersCustomizer.class);
+            ReflectionUtils.makeAccessible(constructor);
+            return (StructuredLogFormatter<ILoggingEvent>) constructor.newInstance(
+                instantiator.getArg(StackTracePrinter.class),
+                instantiator.getArg(ContextPairs.class),
+                instantiator.getArg(ThrowableProxyConverter.class),
+                new CompositeStructuredLoggingJsonMembersCustomizer<>(instantiator
+                    .getArg(StructuredLoggingJsonMembersCustomizer.class),
+                    createTraceContextCustomizer(environment)));
+        } catch (ReflectiveOperationException ex) {
+            throw new IllegalStateException("Failed to create Logstash structured log formatter",
+                ex);
+        }
+    }
+
+    private StructuredLoggingJsonMembersCustomizer<ILoggingEvent> createTraceContextCustomizer(
+                                                                                               Environment environment) {
+        boolean tracerStructured = environment.getProperty("logging.sofa.tracer.output-structured",
+            Boolean.class, environment.getProperty("sofa.boot.tracer.output-structured",
+                Boolean.class, false));
+        if (!tracerStructured) {
+            return (members) -> {
+            };
+        }
+        return (members) -> {
+            members.add("trace", (event) -> SofaTracerContextAccessor.current()).whenNotNull()
+                .usingMembers((trace) -> trace.add("id", SofaTracerContextSnapshot::getTraceId)
+                    .whenHasLength());
+            members.add("span", (event) -> SofaTracerContextAccessor.current()).whenNotNull()
+                .usingMembers((span) -> span.add("id", SofaTracerContextSnapshot::getSpanId)
+                    .whenHasLength());
+            members.add("parent", (event) -> SofaTracerContextAccessor.current()).whenNotNull()
+                .usingMembers((parent) -> parent.add("id",
+                    SofaTracerContextSnapshot::getParentId).whenHasLength());
+        };
+    }
+
+    private String resolveFormat(String candidate) {
+        if (!StringUtils.hasText(candidate)) {
+            return null;
+        }
+        if (candidate.contains("${") || candidate.endsWith("_IS_UNDEFINED")) {
+            return null;
+        }
+        return candidate.trim();
+    }
+
+    private static final class CompositeStructuredLoggingJsonMembersCustomizer<T>
+                                                                                  implements
+                                                                                  StructuredLoggingJsonMembersCustomizer<T> {
+
+        private final List<StructuredLoggingJsonMembersCustomizer<T>> delegates;
+
+        @SafeVarargs
+        private CompositeStructuredLoggingJsonMembersCustomizer(StructuredLoggingJsonMembersCustomizer<T>... delegates) {
+            this.delegates = new ArrayList<>();
+            for (StructuredLoggingJsonMembersCustomizer<T> delegate : delegates) {
+                if (delegate != null) {
+                    this.delegates.add(delegate);
+                }
+            }
+        }
+
+        @Override
+        public void customize(org.springframework.boot.json.JsonWriter.Members<T> members) {
+            for (StructuredLoggingJsonMembersCustomizer<T> delegate : this.delegates) {
+                delegate.customize(members);
+            }
+        }
+    }
+
+    private static final class CompositeJsonMembersCustomizerBuilder<T>
+                                                                        implements
+                                                                        StructuredLoggingJsonMembersCustomizer.Builder<T> {
+
+        private final StructuredLoggingJsonMembersCustomizer.Builder<T> delegate;
+
+        private final StructuredLoggingJsonMembersCustomizer<T>         extraCustomizer;
+
+        private CompositeJsonMembersCustomizerBuilder(StructuredLoggingJsonMembersCustomizer.Builder<T> delegate,
+                                                      StructuredLoggingJsonMembersCustomizer<T> extraCustomizer) {
+            this.delegate = delegate;
+            this.extraCustomizer = extraCustomizer;
+        }
+
+        @Override
+        public StructuredLoggingJsonMembersCustomizer.Builder<T> nested(boolean nested) {
+            return new CompositeJsonMembersCustomizerBuilder<>(this.delegate.nested(nested),
+                this.extraCustomizer);
+        }
+
+        @Override
+        public StructuredLoggingJsonMembersCustomizer<T> build() {
+            return new CompositeStructuredLoggingJsonMembersCustomizer<>(this.delegate.build(),
+                this.extraCustomizer);
+        }
+    }
+
+    static final class SofaTracerContextSnapshot {
+
+        private final String traceId;
+
+        private final String spanId;
+
+        private final String parentId;
+
+        SofaTracerContextSnapshot(String traceId, String spanId, String parentId) {
+            this.traceId = traceId;
+            this.spanId = spanId;
+            this.parentId = parentId;
+        }
+
+        String getTraceId() {
+            return this.traceId;
+        }
+
+        String getSpanId() {
+            return this.spanId;
+        }
+
+        String getParentId() {
+            return this.parentId;
+        }
+    }
+
+    static final class SofaTracerContextAccessor {
+
+        private static final Method HOLDER_METHOD;
+
+        private static final Method GET_CURRENT_SPAN_METHOD;
+
+        private static final Method GET_SPAN_CONTEXT_METHOD;
+
+        private static final Method GET_TRACE_ID_METHOD;
+
+        private static final Method GET_SPAN_ID_METHOD;
+
+        private static final Method GET_PARENT_ID_METHOD;
+
+        static {
+            Method holderMethod = null;
+            Method getCurrentSpanMethod = null;
+            Method getSpanContextMethod = null;
+            Method getTraceIdMethod = null;
+            Method getSpanIdMethod = null;
+            Method getParentIdMethod = null;
+            try {
+                Class<?> holderClass = ClassUtils.forName(
+                    "com.alipay.common.tracer.core.holder.SofaTraceContextHolder", null);
+                Class<?> traceContextClass = ClassUtils.forName(
+                    "com.alipay.common.tracer.core.context.trace.SofaTraceContext", null);
+                Class<?> spanClass = ClassUtils.forName(
+                    "com.alipay.common.tracer.core.span.SofaTracerSpan", null);
+                Class<?> spanContextClass = ClassUtils.forName(
+                    "com.alipay.common.tracer.core.context.span.SofaTracerSpanContext", null);
+                holderMethod = holderClass.getMethod("getSofaTraceContext");
+                getCurrentSpanMethod = traceContextClass.getMethod("getCurrentSpan");
+                getSpanContextMethod = spanClass.getMethod("getSofaTracerSpanContext");
+                getTraceIdMethod = spanContextClass.getMethod("getTraceId");
+                getSpanIdMethod = spanContextClass.getMethod("getSpanId");
+                getParentIdMethod = spanContextClass.getMethod("getParentId");
+            } catch (ClassNotFoundException | NoSuchMethodException ex) {
+                holderMethod = null;
+                getCurrentSpanMethod = null;
+                getSpanContextMethod = null;
+                getTraceIdMethod = null;
+                getSpanIdMethod = null;
+                getParentIdMethod = null;
+            }
+            HOLDER_METHOD = holderMethod;
+            GET_CURRENT_SPAN_METHOD = getCurrentSpanMethod;
+            GET_SPAN_CONTEXT_METHOD = getSpanContextMethod;
+            GET_TRACE_ID_METHOD = getTraceIdMethod;
+            GET_SPAN_ID_METHOD = getSpanIdMethod;
+            GET_PARENT_ID_METHOD = getParentIdMethod;
+        }
+
+        private SofaTracerContextAccessor() {
+        }
+
+        static SofaTracerContextSnapshot current() {
+            if (HOLDER_METHOD == null) {
+                return null;
+            }
+            try {
+                Object traceContext = HOLDER_METHOD.invoke(null);
+                Object span = GET_CURRENT_SPAN_METHOD.invoke(traceContext);
+                if (span == null) {
+                    return null;
+                }
+                Object spanContext = GET_SPAN_CONTEXT_METHOD.invoke(span);
+                if (spanContext == null) {
+                    return null;
+                }
+                return new SofaTracerContextSnapshot(
+                    (String) GET_TRACE_ID_METHOD.invoke(spanContext),
+                    (String) GET_SPAN_ID_METHOD.invoke(spanContext),
+                    (String) GET_PARENT_ID_METHOD.invoke(spanContext));
+            } catch (IllegalAccessException ex) {
+                return null;
+            } catch (InvocationTargetException ex) {
+                if (ex.getTargetException() instanceof java.util.EmptyStackException) {
+                    return null;
+                }
+                return null;
+            }
+        }
+    }
+}

--- a/sofa-boot-project/sofa-boot/src/main/resources/sofa-boot/log/logback/log-conf.xml
+++ b/sofa-boot-project/sofa-boot/src/main/resources/sofa-boot/log/logback/log-conf.xml
@@ -27,7 +27,8 @@
             <FileNamePattern>${logging.path}/sofa-runtime/common-error.log.%d{yyyy-MM-dd}</FileNamePattern>
             <MaxHistory>30</MaxHistory>
         </rollingPolicy>
-        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+        <encoder class="com.alipay.sofa.boot.logging.logback.SofaStructuredLogEncoder">
+            <format>${FILE_LOG_STRUCTURED_FORMAT}</format>
             <pattern>%d %-5p %-32t - %m%n</pattern>
             <charset>${file.encoding}</charset>
         </encoder>
@@ -43,7 +44,8 @@
             <FileNamePattern>${logging.path}/sofa-runtime/sofa-default.log.%d{yyyy-MM-dd}</FileNamePattern>
             <MaxHistory>30</MaxHistory>
         </rollingPolicy>
-        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+        <encoder class="com.alipay.sofa.boot.logging.logback.SofaStructuredLogEncoder">
+            <format>${FILE_LOG_STRUCTURED_FORMAT}</format>
             <pattern>%d %-5p %-32t - %m%n</pattern>
             <charset>${file.encoding}</charset>
         </encoder>
@@ -66,7 +68,8 @@
             <!--日志文件保留天数-->
             <MaxHistory>30</MaxHistory>
         </rollingPolicy>
-        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+        <encoder class="com.alipay.sofa.boot.logging.logback.SofaStructuredLogEncoder">
+            <format>${FILE_LOG_STRUCTURED_FORMAT}</format>
             <pattern>%d %-5p %-32t - %m%n</pattern>
             <!-- 编码 -->
             <charset>${file.encoding}</charset>
@@ -88,7 +91,8 @@
             <!--日志文件保留天数-->
             <MaxHistory>30</MaxHistory>
         </rollingPolicy>
-        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+        <encoder class="com.alipay.sofa.boot.logging.logback.SofaStructuredLogEncoder">
+            <format>${FILE_LOG_STRUCTURED_FORMAT}</format>
             <pattern>%d %-5p %-32t - %m%n</pattern>
             <!-- 编码 -->
             <charset>${file.encoding}</charset>

--- a/sofa-boot-project/sofa-boot/src/test/java/com/alipay/sofa/boot/logging/LogEnvironmentPreparingListenerTests.java
+++ b/sofa-boot-project/sofa-boot/src/test/java/com/alipay/sofa/boot/logging/LogEnvironmentPreparingListenerTests.java
@@ -68,4 +68,29 @@ public class LogEnvironmentPreparingListenerTests {
             .isEqualTo("false");
         System.clearProperty(SofaThreadPoolConstants.SOFA_THREAD_POOL_LOGGING_CAPABILITY);
     }
+
+    @Test
+    public void registerStructuredLoggingProperties() {
+        LogEnvironmentPostProcessor logEnvironmentPostProcessor = new LogEnvironmentPostProcessor();
+        MockEnvironment environment = new MockEnvironment();
+        environment.setProperty("logging.structured.format.file", "ecs");
+        environment.setProperty("logging.structured.json.add.region", "cn");
+        environment.setProperty("logging.sofa.tracer.output-structured", "true");
+        environment.setProperty("spring.application.name", "sofa-app");
+
+        logEnvironmentPostProcessor.postProcessEnvironment(environment, null);
+
+        assertThat(
+            CommonLoggingConfigurations.getExternalConfigurations().get(
+                LogEnvironmentPostProcessor.FILE_LOG_STRUCTURED_FORMAT)).isEqualTo("ecs");
+        assertThat(
+            CommonLoggingConfigurations.getExternalConfigurations().get(
+                "logging.structured.json.add.region")).isEqualTo("cn");
+        assertThat(
+            CommonLoggingConfigurations.getExternalConfigurations().get(
+                "logging.sofa.tracer.output-structured")).isEqualTo("true");
+        assertThat(
+            CommonLoggingConfigurations.getExternalConfigurations().get("spring.application.name"))
+            .isEqualTo("sofa-app");
+    }
 }

--- a/sofa-boot-project/sofa-boot/src/test/java/com/alipay/sofa/boot/logging/logback/SofaStructuredLogEncoderTests.java
+++ b/sofa-boot-project/sofa-boot/src/test/java/com/alipay/sofa/boot/logging/logback/SofaStructuredLogEncoderTests.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.boot.logging.logback;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.LoggingEvent;
+import com.alipay.common.tracer.core.SofaTracer;
+import com.alipay.common.tracer.core.context.span.SofaTracerSpanContext;
+import com.alipay.common.tracer.core.holder.SofaTraceContextHolder;
+import com.alipay.common.tracer.core.span.SofaTracerSpan;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link SofaStructuredLogEncoder}.
+ */
+public class SofaStructuredLogEncoderTests {
+
+    @AfterEach
+    void clearTraceContext() {
+        SofaTraceContextHolder.getSofaTraceContext().clear();
+    }
+
+    @Test
+    void shouldFallbackToPatternWhenStructuredFormatIsNotConfigured() {
+        LoggerContext context = new LoggerContext();
+        SofaStructuredLogEncoder encoder = new SofaStructuredLogEncoder();
+        encoder.setContext(context);
+        encoder.setPattern("%msg%n");
+        encoder.start();
+
+        String output = new String(encoder.encode(createEvent(context, "plain-message")),
+            StandardCharsets.UTF_8);
+
+        assertThat(output).isEqualTo("plain-message" + System.lineSeparator());
+    }
+
+    @Test
+    void shouldOutputEcsStructuredLogWhenFormatConfigured() {
+        LoggerContext context = new LoggerContext();
+        context.putProperty("logging.structured.ecs.service.name", "structured-test");
+
+        SofaStructuredLogEncoder encoder = new SofaStructuredLogEncoder();
+        encoder.setContext(context);
+        encoder.setFormat("ecs");
+        encoder.setPattern("%msg%n");
+        encoder.start();
+
+        String output = new String(encoder.encode(createEvent(context, "structured-message")),
+            StandardCharsets.UTF_8);
+
+        assertThat(output).contains("\"message\":\"structured-message\"");
+        assertThat(output).contains("\"service\":{\"name\":\"structured-test\"");
+    }
+
+    @Test
+    void shouldInjectTracerContextWhenStructuredTracerLoggingIsEnabled() {
+        LoggerContext context = new LoggerContext();
+        context.putProperty("logging.structured.ecs.service.name", "structured-test");
+        context.putProperty("logging.sofa.tracer.output-structured", "true");
+
+        SofaTracerSpanContext spanContext = new SofaTracerSpanContext("trace-1", "1.2", "1.1");
+        SofaTracerSpan span = new SofaTracerSpan(Mockito.mock(SofaTracer.class),
+            System.currentTimeMillis(), "testOperation", spanContext, Collections.emptyMap());
+        SofaTraceContextHolder.getSofaTraceContext().push(span);
+
+        SofaStructuredLogEncoder encoder = new SofaStructuredLogEncoder();
+        encoder.setContext(context);
+        encoder.setFormat("ecs");
+        encoder.setPattern("%msg%n");
+        encoder.start();
+
+        String output = new String(encoder.encode(createEvent(context, "trace-message")),
+            StandardCharsets.UTF_8);
+
+        assertThat(output).contains("\"trace\":{\"id\":\"trace-1\"}");
+        assertThat(output).contains("\"span\":{\"id\":\"1.2\"}");
+        assertThat(output).contains("\"parent\":{\"id\":\"1.1\"}");
+    }
+
+    private LoggingEvent createEvent(LoggerContext context, String message) {
+        Logger logger = context.getLogger("structured.logger");
+        LoggingEvent event = new LoggingEvent(Logger.class.getName(), logger, Level.INFO, message,
+            null, null);
+        event.setLoggerContext(context);
+        event.setTimeStamp(System.currentTimeMillis());
+        event.setMDCPropertyMap(Collections.emptyMap());
+        return event;
+    }
+}

--- a/sofa-boot-project/sofa-boot/src/test/java/com/alipay/sofa/boot/logging/logback/SofaStructuredLogEncoderTests.java
+++ b/sofa-boot-project/sofa-boot/src/test/java/com/alipay/sofa/boot/logging/logback/SofaStructuredLogEncoderTests.java
@@ -32,6 +32,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 
 /**
  * Tests for {@link SofaStructuredLogEncoder}.
@@ -58,6 +59,47 @@ public class SofaStructuredLogEncoderTests {
     }
 
     @Test
+    void shouldFallbackToPatternWhenFormatContainsPlaceholder() {
+        LoggerContext context = new LoggerContext();
+        SofaStructuredLogEncoder encoder = new SofaStructuredLogEncoder();
+        encoder.setContext(context);
+        encoder.setFormat("${FILE_LOG_STRUCTURED_FORMAT}");
+        encoder.setPattern("%msg%n");
+        encoder.start();
+
+        String output = new String(encoder.encode(createEvent(context, "placeholder-message")),
+            StandardCharsets.UTF_8);
+
+        assertThat(output).isEqualTo("placeholder-message" + System.lineSeparator());
+    }
+
+    @Test
+    void shouldFallbackToPatternWhenFormatIsUndefinedMarker() {
+        LoggerContext context = new LoggerContext();
+        SofaStructuredLogEncoder encoder = new SofaStructuredLogEncoder();
+        encoder.setContext(context);
+        encoder.setFormat("FILE_LOG_STRUCTURED_FORMAT_IS_UNDEFINED");
+        encoder.setPattern("%msg%n");
+        encoder.start();
+
+        String output = new String(encoder.encode(createEvent(context, "undefined-message")),
+            StandardCharsets.UTF_8);
+
+        assertThat(output).isEqualTo("undefined-message" + System.lineSeparator());
+    }
+
+    @Test
+    void shouldFailFastWhenPatternIsMissingForPatternFallback() {
+        LoggerContext context = new LoggerContext();
+        SofaStructuredLogEncoder encoder = new SofaStructuredLogEncoder();
+        encoder.setContext(context);
+        encoder.setFormat("${FILE_LOG_STRUCTURED_FORMAT}");
+
+        assertThatIllegalStateException().isThrownBy(encoder::start)
+            .withMessage("Pattern has not been set");
+    }
+
+    @Test
     void shouldOutputEcsStructuredLogWhenFormatConfigured() {
         LoggerContext context = new LoggerContext();
         context.putProperty("logging.structured.ecs.service.name", "structured-test");
@@ -73,6 +115,24 @@ public class SofaStructuredLogEncoderTests {
 
         assertThat(output).contains("\"message\":\"structured-message\"");
         assertThat(output).contains("\"service\":{\"name\":\"structured-test\"");
+    }
+
+    @Test
+    void shouldOutputLogstashStructuredLogWhenFormatContainsWhitespace() {
+        LoggerContext context = new LoggerContext();
+
+        SofaStructuredLogEncoder encoder = new SofaStructuredLogEncoder();
+        encoder.setContext(context);
+        encoder.setCharset(null);
+        encoder.setFormat(" logstash ");
+        encoder.setPattern("%msg%n");
+        encoder.start();
+
+        String output = new String(encoder.encode(createEvent(context, "logstash-message")),
+            StandardCharsets.UTF_8);
+
+        assertThat(output).contains("\"@timestamp\":");
+        assertThat(output).contains("\"message\":\"logstash-message\"");
     }
 
     @Test
@@ -98,6 +158,97 @@ public class SofaStructuredLogEncoderTests {
         assertThat(output).contains("\"trace\":{\"id\":\"trace-1\"}");
         assertThat(output).contains("\"span\":{\"id\":\"1.2\"}");
         assertThat(output).contains("\"parent\":{\"id\":\"1.1\"}");
+    }
+
+    @Test
+    void shouldInjectTracerContextWhenAliasPropertyIsEnabled() {
+        LoggerContext context = new LoggerContext();
+        context.putProperty("logging.structured.ecs.service.name", "structured-test");
+        context.putProperty("sofa.boot.tracer.output-structured", "true");
+
+        SofaTracerSpanContext spanContext = new SofaTracerSpanContext("trace-2", "2.2", "2.1");
+        SofaTracerSpan span = new SofaTracerSpan(Mockito.mock(SofaTracer.class),
+            System.currentTimeMillis(), "testOperation", spanContext, Collections.emptyMap());
+        SofaTraceContextHolder.getSofaTraceContext().push(span);
+
+        SofaStructuredLogEncoder encoder = new SofaStructuredLogEncoder();
+        encoder.setContext(context);
+        encoder.setFormat("ecs");
+        encoder.setPattern("%msg%n");
+        encoder.start();
+
+        String output = new String(encoder.encode(createEvent(context, "alias-trace-message")),
+            StandardCharsets.UTF_8);
+
+        assertThat(output).contains("\"trace\":{\"id\":\"trace-2\"}");
+        assertThat(output).contains("\"span\":{\"id\":\"2.2\"}");
+        assertThat(output).contains("\"parent\":{\"id\":\"2.1\"}");
+    }
+
+    @Test
+    void shouldSkipTracerFieldsWhenNoCurrentSpanExists() {
+        LoggerContext context = new LoggerContext();
+        context.putProperty("logging.structured.ecs.service.name", "structured-test");
+        context.putProperty("logging.sofa.tracer.output-structured", "true");
+
+        SofaStructuredLogEncoder encoder = new SofaStructuredLogEncoder();
+        encoder.setContext(context);
+        encoder.setFormat("ecs");
+        encoder.setPattern("%msg%n");
+        encoder.start();
+
+        String output = new String(encoder.encode(createEvent(context, "no-trace-message")),
+            StandardCharsets.UTF_8);
+
+        assertThat(output).contains("\"message\":\"no-trace-message\"");
+        assertThat(output).doesNotContain("\"trace\"");
+        assertThat(output).doesNotContain("\"span\"");
+        assertThat(output).doesNotContain("\"parent\"");
+    }
+
+    @Test
+    void shouldReturnNullHeaderAndFooterAndStopCleanly() {
+        LoggerContext context = new LoggerContext();
+        SofaStructuredLogEncoder encoder = new SofaStructuredLogEncoder();
+        encoder.setContext(context);
+        encoder.setPattern("%msg%n");
+        encoder.start();
+
+        assertThat(encoder.headerBytes()).isNull();
+        assertThat(encoder.footerBytes()).isNull();
+        assertThat(encoder.isStarted()).isTrue();
+
+        encoder.stop();
+
+        assertThat(encoder.isStarted()).isFalse();
+    }
+
+    @Test
+    void shouldExposeCurrentTracerSnapshot() {
+        assertThat(SofaStructuredLogEncoder.SofaTracerContextAccessor.current()).isNull();
+
+        SofaTracerSpanContext spanContext = new SofaTracerSpanContext("trace-3", "3.2", "3.1");
+        SofaTracerSpan span = new SofaTracerSpan(Mockito.mock(SofaTracer.class),
+            System.currentTimeMillis(), "testOperation", spanContext, Collections.emptyMap());
+        SofaTraceContextHolder.getSofaTraceContext().push(span);
+
+        SofaStructuredLogEncoder.SofaTracerContextSnapshot snapshot = SofaStructuredLogEncoder.SofaTracerContextAccessor
+            .current();
+
+        assertThat(snapshot).isNotNull();
+        assertThat(snapshot.getTraceId()).isEqualTo("trace-3");
+        assertThat(snapshot.getSpanId()).isEqualTo("3.2");
+        assertThat(snapshot.getParentId()).isEqualTo("3.1");
+    }
+
+    @Test
+    void shouldAllowSnapshotWithNullParentId() {
+        SofaStructuredLogEncoder.SofaTracerContextSnapshot snapshot = new SofaStructuredLogEncoder.SofaTracerContextSnapshot(
+            "trace-4", "4.2", null);
+
+        assertThat(snapshot.getTraceId()).isEqualTo("trace-4");
+        assertThat(snapshot.getSpanId()).isEqualTo("4.2");
+        assertThat(snapshot.getParentId()).isNull();
     }
 
     private LoggingEvent createEvent(LoggerContext context, String message) {

--- a/sofa-boot-project/sofaboot-dependencies/pom.xml
+++ b/sofa-boot-project/sofaboot-dependencies/pom.xml
@@ -122,6 +122,12 @@
             </dependency>
 
             <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-starter-validation</artifactId>
+                <version>${spring.boot.version}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>com.alipay.sofa</groupId>
                 <artifactId>sofa-boot</artifactId>
                 <version>${sofa.boot.version}</version>


### PR DESCRIPTION
Related #1402
- Added SofaStructuredLogEncoder to support switching SOFA Logback outputs between pattern logging and structured logging (ecs / logstash).

- Extended LogEnvironmentPostProcessor to bridge logging.structured.*, logging.sofa.tracer.*, and spring.application.* into SOFA logger spaces.

- Updated SOFABoot runtime and RPC Logback templates to use the new encoder, enabling structured output in SOFA-managed log files.

- Added tracer-context injection support so structured application logs can include trace.id, span.id, and parent.id when logging.sofa.tracer.output-structured=true.

- Added focused tests covering pattern fallback, ECS output, property propagation, and tracer context injection.