### PR TITLE
[AI-8th]Add ProblemDetail (RFC 7807) support for standardized SOFABoot REST error responses

### DIFF
--- a/sofa-boot-project/sofa-boot-actuator-autoconfigure/pom.xml
+++ b/sofa-boot-project/sofa-boot-actuator-autoconfigure/pom.xml
@@ -33,6 +33,11 @@
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-configuration-processor</artifactId>
             <optional>true</optional>
         </dependency>

--- a/sofa-boot-project/sofa-boot-actuator-autoconfigure/src/main/java/com/alipay/sofa/boot/actuator/autoconfigure/health/HealthProperties.java
+++ b/sofa-boot-project/sofa-boot-actuator-autoconfigure/src/main/java/com/alipay/sofa/boot/actuator/autoconfigure/health/HealthProperties.java
@@ -17,8 +17,10 @@
 package com.alipay.sofa.boot.actuator.autoconfigure.health;
 
 import com.alipay.sofa.boot.actuator.health.HealthCheckerConfig;
+import jakarta.validation.constraints.Positive;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
+import org.springframework.validation.annotation.Validated;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -33,6 +35,7 @@ import java.util.Map;
  * Created on 2020/5/18
  */
 @ConfigurationProperties("sofa.boot.actuator.health")
+@Validated
 public class HealthProperties {
 
     /**
@@ -54,6 +57,7 @@ public class HealthProperties {
     /**
      * Timeout duration of parallel health check, in milliseconds.
      */
+    @Positive(message = "并行健康检查超时时间必须大于 0")
     private long                                                                                parallelCheckTimeout         = 120 * 1000;
 
     /**
@@ -84,6 +88,7 @@ public class HealthProperties {
     /**
      * Global {@link com.alipay.sofa.boot.actuator.health.HealthChecker} health check timeout，in milliseconds.
      */
+    @Positive(message = "HealthChecker 全局超时时间必须大于 0")
     private int                                                                                 globalHealthCheckerTimeout   = 60 * 1000;
 
     /**
@@ -95,6 +100,7 @@ public class HealthProperties {
     /**
      * Global {@link org.springframework.boot.actuate.health.HealthIndicator} health check timeout，in milliseconds.
      */
+    @Positive(message = "HealthIndicator 全局超时时间必须大于 0")
     private int                                                                                 globalHealthIndicatorTimeout = 60 * 1000;
 
     /**

--- a/sofa-boot-project/sofa-boot-actuator-autoconfigure/src/test/java/com/alipay/sofa/boot/actuator/autoconfigure/health/ReadinessAutoConfigurationTests.java
+++ b/sofa-boot-project/sofa-boot-actuator-autoconfigure/src/test/java/com/alipay/sofa/boot/actuator/autoconfigure/health/ReadinessAutoConfigurationTests.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.condition.JRE;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.core.NestedExceptionUtils;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -145,6 +146,17 @@ public class ReadinessAutoConfigurationTests {
                     assertThat(context.getBean(HealthIndicatorProcessor.class).isParallelCheck()).isFalse();
                     assertThat(context.getBean(HealthIndicatorProcessor.class).getParallelCheckTimeout()).isEqualTo(30000);
                     assertThat(context.getBean(ReadinessCheckListener.READINESS_HEALTH_CHECK_EXECUTOR_BEAN_NAME, ThreadPoolExecutor.class).getMaximumPoolSize()).isEqualTo(1);
+                });
+    }
+
+    @Test
+    void invalidHealthPropertiesShouldFailFast() {
+        this.contextRunner
+                .withPropertyValues("sofa.boot.actuator.health.parallelCheckTimeout=0")
+                .run((context) -> {
+                    assertThat(context).hasFailed();
+                    assertThat(NestedExceptionUtils.getMostSpecificCause(context.getStartupFailure()).getMessage())
+                            .contains("并行健康检查超时时间必须大于 0");
                 });
     }
 

--- a/sofa-boot-project/sofa-boot-autoconfigure/pom.xml
+++ b/sofa-boot-project/sofa-boot-autoconfigure/pom.xml
@@ -28,6 +28,11 @@
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-configuration-processor</artifactId>
             <optional>true</optional>
         </dependency>

--- a/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/isle/SofaModuleProperties.java
+++ b/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/isle/SofaModuleProperties.java
@@ -16,7 +16,9 @@
  */
 package com.alipay.sofa.boot.autoconfigure.isle;
 
+import jakarta.validation.constraints.Positive;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -28,6 +30,7 @@ import java.util.List;
  * @author huzijie
  */
 @ConfigurationProperties("sofa.boot.isle")
+@Validated
 public class SofaModuleProperties {
 
     /**
@@ -78,16 +81,19 @@ public class SofaModuleProperties {
     /**
      * Thead pool size factor used in parallel sofa module application context refresh.
      */
+    @Positive(message = "模块并行刷新线程池倍率必须大于 0")
     private float        parallelRefreshPoolSizeFactor = 5.0f;
 
     /**
      * Timeout used in parallel sofa module application context refresh, in milliseconds.
      */
+    @Positive(message = "模块并行刷新超时时间必须大于 0")
     private long         parallelRefreshTimeout        = 60;
 
     /**
      * Monitor period used in parallel sofa module application context refresh, in milliseconds.
      */
+    @Positive(message = "模块并行刷新检查周期必须大于 0")
     private long         parallelRefreshCheckPeriod    = 30;
 
     public List<String> getActiveProfiles() {

--- a/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/problem/AbstractSofaProblemDetailExceptionMapper.java
+++ b/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/problem/AbstractSofaProblemDetailExceptionMapper.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.boot.autoconfigure.problem;
+
+import org.springframework.http.ProblemDetail;
+import org.springframework.util.StringUtils;
+
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+import javax.ws.rs.ext.ExceptionMapper;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Base JAX-RS exception mapper for SOFA problem detail responses.
+ *
+ * @author OpenAI
+ */
+public abstract class AbstractSofaProblemDetailExceptionMapper<T extends Throwable>
+                                                                                    implements
+                                                                                    ExceptionMapper<T> {
+
+    private final SofaProblemDetailFactory factory;
+
+    @Context
+    private UriInfo                        uriInfo;
+
+    @Context
+    private HttpHeaders                    headers;
+
+    protected AbstractSofaProblemDetailExceptionMapper(SofaProblemDetailFactory factory) {
+        this.factory = factory;
+    }
+
+    @Override
+    public Response toResponse(T exception) {
+        ProblemDetail problemDetail = factory.create(exception, resolveInstancePath(),
+            resolveLocale());
+        return Response.status(problemDetail.getStatus())
+            .type(MediaType.valueOf("application/problem+json"))
+            .entity(factory.render(problemDetail)).build();
+    }
+
+    private String resolveInstancePath() {
+        if (uriInfo == null || uriInfo.getRequestUri() == null) {
+            return null;
+        }
+        String path = uriInfo.getRequestUri().getPath();
+        if (!StringUtils.hasText(path)) {
+            return null;
+        }
+        return path.startsWith("/") ? path : "/" + path;
+    }
+
+    private Locale resolveLocale() {
+        if (headers == null) {
+            return Locale.getDefault();
+        }
+        List<Locale> acceptableLanguages = headers.getAcceptableLanguages();
+        return acceptableLanguages.isEmpty() ? Locale.getDefault() : acceptableLanguages.get(0);
+    }
+}

--- a/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/problem/SofaBootRpcRuntimeExceptionProblemDetailExceptionMapper.java
+++ b/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/problem/SofaBootRpcRuntimeExceptionProblemDetailExceptionMapper.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.boot.autoconfigure.problem;
+
+import com.alipay.sofa.rpc.boot.common.SofaBootRpcRuntimeException;
+
+import javax.ws.rs.ext.Provider;
+
+/**
+ * JAX-RS mapper for {@link SofaBootRpcRuntimeException}.
+ *
+ * @author OpenAI
+ */
+@Provider
+public class SofaBootRpcRuntimeExceptionProblemDetailExceptionMapper
+                                                                    extends
+                                                                    AbstractSofaProblemDetailExceptionMapper<SofaBootRpcRuntimeException> {
+
+    public SofaBootRpcRuntimeExceptionProblemDetailExceptionMapper(SofaProblemDetailFactory factory) {
+        super(factory);
+    }
+}

--- a/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/problem/SofaProblemDetailAutoConfiguration.java
+++ b/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/problem/SofaProblemDetailAutoConfiguration.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.boot.autoconfigure.problem;
+
+import com.alipay.sofa.boot.autoconfigure.rpc.SofaRpcAutoConfiguration;
+import com.alipay.sofa.rpc.config.JAXRSProviderManager;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.MessageSource;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+import org.springframework.http.ProblemDetail;
+
+import javax.ws.rs.ext.ExceptionMapper;
+
+/**
+ * Auto-configuration for SOFABoot problem detail support.
+ *
+ * @author OpenAI
+ */
+@AutoConfiguration(after = SofaRpcAutoConfiguration.class)
+@ConditionalOnClass(ProblemDetail.class)
+@ConditionalOnProperty(prefix = "sofa.boot.problem-detail", name = "enabled", havingValue = "true", matchIfMissing = true)
+@EnableConfigurationProperties(SofaProblemDetailProperties.class)
+public class SofaProblemDetailAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean
+    public SofaProblemDetailFactory sofaProblemDetailFactory(SofaProblemDetailProperties properties,
+                                                             ObjectProvider<MessageSource> messageSource,
+                                                             Environment environment) {
+        return new SofaProblemDetailFactory(properties, messageSource.getIfAvailable(), environment);
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    @ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
+    static class ServletProblemDetailConfiguration {
+
+        @Bean
+        @ConditionalOnMissingBean
+        public SofaProblemDetailExceptionHandler sofaProblemDetailExceptionHandler(SofaProblemDetailFactory factory) {
+            return new SofaProblemDetailExceptionHandler(factory);
+        }
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    @ConditionalOnClass({ ExceptionMapper.class, JAXRSProviderManager.class })
+    static class JaxrsProblemDetailConfiguration {
+
+        @Bean
+        @ConditionalOnMissingBean
+        public SofaRpcExceptionProblemDetailExceptionMapper sofaRpcExceptionProblemDetailExceptionMapper(SofaProblemDetailFactory factory) {
+            SofaRpcExceptionProblemDetailExceptionMapper mapper = new SofaRpcExceptionProblemDetailExceptionMapper(
+                factory);
+            JAXRSProviderManager.registerCustomProviderInstance(mapper);
+            return mapper;
+        }
+
+        @Bean
+        @ConditionalOnMissingBean
+        public SofaRpcRuntimeExceptionProblemDetailExceptionMapper sofaRpcRuntimeExceptionProblemDetailExceptionMapper(SofaProblemDetailFactory factory) {
+            SofaRpcRuntimeExceptionProblemDetailExceptionMapper mapper = new SofaRpcRuntimeExceptionProblemDetailExceptionMapper(
+                factory);
+            JAXRSProviderManager.registerCustomProviderInstance(mapper);
+            return mapper;
+        }
+
+        @Bean
+        @ConditionalOnMissingBean
+        public SofaBootRpcRuntimeExceptionProblemDetailExceptionMapper sofaBootRpcRuntimeExceptionProblemDetailExceptionMapper(SofaProblemDetailFactory factory) {
+            SofaBootRpcRuntimeExceptionProblemDetailExceptionMapper mapper = new SofaBootRpcRuntimeExceptionProblemDetailExceptionMapper(
+                factory);
+            JAXRSProviderManager.registerCustomProviderInstance(mapper);
+            return mapper;
+        }
+    }
+}

--- a/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/problem/SofaProblemDetailExceptionHandler.java
+++ b/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/problem/SofaProblemDetailExceptionHandler.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.boot.autoconfigure.problem;
+
+import com.alipay.sofa.rpc.boot.common.SofaBootRpcRuntimeException;
+import com.alipay.sofa.rpc.core.exception.SofaRpcException;
+import com.alipay.sofa.rpc.core.exception.SofaRpcRuntimeException;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.MediaType;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.Locale;
+
+/**
+ * MVC exception handler that renders SOFA exceptions as RFC 7807 problem details.
+ *
+ * @author OpenAI
+ */
+@RestControllerAdvice
+@Order(Ordered.LOWEST_PRECEDENCE)
+public class SofaProblemDetailExceptionHandler {
+
+    private final SofaProblemDetailFactory factory;
+
+    public SofaProblemDetailExceptionHandler(SofaProblemDetailFactory factory) {
+        this.factory = factory;
+    }
+
+    @ExceptionHandler(SofaRpcException.class)
+    public ResponseEntity<ProblemDetail> handleSofaRpcException(SofaRpcException exception,
+                                                                HttpServletRequest request,
+                                                                Locale locale) {
+        return buildResponse(factory.create(exception, request.getRequestURI(), locale));
+    }
+
+    @ExceptionHandler(SofaRpcRuntimeException.class)
+    public ResponseEntity<ProblemDetail> handleSofaRpcRuntimeException(SofaRpcRuntimeException exception,
+                                                                       HttpServletRequest request,
+                                                                       Locale locale) {
+        return buildResponse(factory.create(exception, request.getRequestURI(), locale));
+    }
+
+    @ExceptionHandler(SofaBootRpcRuntimeException.class)
+    public ResponseEntity<ProblemDetail> handleSofaBootRpcRuntimeException(SofaBootRpcRuntimeException exception,
+                                                                           HttpServletRequest request,
+                                                                           Locale locale) {
+        return buildResponse(factory.create(exception, request.getRequestURI(), locale));
+    }
+
+    private ResponseEntity<ProblemDetail> buildResponse(ProblemDetail problemDetail) {
+        return ResponseEntity.status(problemDetail.getStatus())
+            .contentType(MediaType.APPLICATION_PROBLEM_JSON).body(problemDetail);
+    }
+}

--- a/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/problem/SofaProblemDetailFactory.java
+++ b/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/problem/SofaProblemDetailFactory.java
@@ -1,0 +1,288 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.boot.autoconfigure.problem;
+
+import com.alipay.sofa.boot.constant.SofaBootConstants;
+import com.alipay.sofa.rpc.boot.common.SofaBootRpcRuntimeException;
+import com.alipay.sofa.rpc.core.exception.RpcErrorType;
+import com.alipay.sofa.rpc.core.exception.SofaRpcException;
+import com.alipay.sofa.rpc.core.exception.SofaRpcRuntimeException;
+import org.springframework.context.MessageSource;
+import org.springframework.core.NestedExceptionUtils;
+import org.springframework.core.env.Environment;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.lang.Nullable;
+import org.springframework.util.ObjectUtils;
+import org.springframework.util.StringUtils;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.net.URI;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Factory for building RFC 7807 problem detail responses for SOFA exceptions.
+ *
+ * @author OpenAI
+ */
+public class SofaProblemDetailFactory {
+
+    private static final String               TITLE_CODE_PREFIX  = "sofa.boot.problem-detail.title.";
+
+    private static final String               DETAIL_CODE_PREFIX = "sofa.boot.problem-detail.detail.";
+
+    private final SofaProblemDetailProperties properties;
+
+    @Nullable
+    private final MessageSource               messageSource;
+
+    private final Environment                 environment;
+
+    public SofaProblemDetailFactory(SofaProblemDetailProperties properties,
+                                    @Nullable MessageSource messageSource, Environment environment) {
+        this.properties = properties;
+        this.messageSource = messageSource;
+        this.environment = environment;
+    }
+
+    public ProblemDetail create(Throwable throwable, @Nullable String instancePath,
+                                @Nullable Locale locale) {
+        Locale targetLocale = locale != null ? locale : Locale.getDefault();
+        if (throwable instanceof SofaRpcException) {
+            return createFromSofaRpcException((SofaRpcException) throwable, instancePath,
+                targetLocale);
+        }
+        if (throwable instanceof SofaRpcRuntimeException) {
+            return createGeneric(throwable, HttpStatus.INTERNAL_SERVER_ERROR, "sofa-rpc/runtime",
+                "sofa-rpc.runtime", "SOFA RPC runtime error", instancePath, targetLocale);
+        }
+        if (throwable instanceof SofaBootRpcRuntimeException) {
+            return createGeneric(throwable, HttpStatus.INTERNAL_SERVER_ERROR,
+                "sofa-rpc/boot-runtime", "sofa-rpc.boot-runtime", "SOFABoot RPC runtime error",
+                instancePath, targetLocale);
+        }
+        return createGeneric(throwable, HttpStatus.INTERNAL_SERVER_ERROR, null, "sofa.default",
+            "Unexpected server error", instancePath, targetLocale);
+    }
+
+    public Map<String, Object> render(ProblemDetail problemDetail) {
+        Map<String, Object> body = new LinkedHashMap<String, Object>();
+        if (problemDetail.getType() != null) {
+            body.put("type", problemDetail.getType().toString());
+        }
+        if (StringUtils.hasText(problemDetail.getTitle())) {
+            body.put("title", problemDetail.getTitle());
+        }
+        body.put("status", problemDetail.getStatus());
+        if (StringUtils.hasText(problemDetail.getDetail())) {
+            body.put("detail", problemDetail.getDetail());
+        }
+        if (problemDetail.getInstance() != null) {
+            body.put("instance", problemDetail.getInstance().toString());
+        }
+        if (!ObjectUtils.isEmpty(problemDetail.getProperties())) {
+            body.putAll(problemDetail.getProperties());
+        }
+        return body;
+    }
+
+    private ProblemDetail createFromSofaRpcException(SofaRpcException exception,
+                                                     @Nullable String instancePath, Locale locale) {
+        String errorCode = resolveRpcErrorCode(exception.getErrorType());
+        HttpStatus status = resolveStatus(exception.getErrorType());
+        String messageKey = "sofa-rpc." + errorCode;
+        String defaultTitle = defaultTitle(exception.getErrorType());
+        ProblemDetail problemDetail = createProblemDetail(
+            exception,
+            status,
+            resolveTitle(messageKey, defaultTitle, locale),
+            resolveDetail(messageKey, exception.getMessage(),
+                defaultDetail(exception, defaultTitle), locale), instancePath);
+        problemDetail.setType(resolveType("sofa-rpc/" + errorCode));
+        problemDetail.setProperty("errorCode", errorCode);
+        problemDetail.setProperty("errorType", exception.getErrorType());
+        appendCommonProperties(problemDetail, exception);
+        return problemDetail;
+    }
+
+    private ProblemDetail createGeneric(Throwable throwable, HttpStatus status,
+                                        @Nullable String typeId, String messageKey,
+                                        String defaultTitle, @Nullable String instancePath,
+                                        Locale locale) {
+        ProblemDetail problemDetail = createProblemDetail(
+            throwable,
+            status,
+            resolveTitle(messageKey, defaultTitle, locale),
+            resolveDetail(messageKey, throwable.getMessage(),
+                defaultDetail(throwable, defaultTitle), locale), instancePath);
+        problemDetail.setType(typeId != null ? resolveType(typeId) : properties.getDefaultType());
+        problemDetail.setProperty("errorCode", messageKey.replace('.', '-'));
+        appendCommonProperties(problemDetail, throwable);
+        return problemDetail;
+    }
+
+    private ProblemDetail createProblemDetail(Throwable throwable, HttpStatus status, String title,
+                                              String detail, @Nullable String instancePath) {
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(status, detail);
+        problemDetail.setTitle(title);
+        if (StringUtils.hasText(instancePath)) {
+            problemDetail.setInstance(URI.create(instancePath));
+        }
+        if (properties.isIncludeServiceInfo()) {
+            String serviceName = environment.getProperty(SofaBootConstants.APP_NAME_KEY);
+            if (StringUtils.hasText(serviceName)) {
+                problemDetail.setProperty("service", serviceName);
+            }
+        }
+        if (properties.isIncludeStackTrace()) {
+            problemDetail.setProperty("stackTrace", buildStackTrace(throwable));
+        }
+        return problemDetail;
+    }
+
+    private void appendCommonProperties(ProblemDetail problemDetail, Throwable throwable) {
+        problemDetail.setProperty("exception", throwable.getClass().getName());
+    }
+
+    private URI resolveType(String problemId) {
+        URI typeBaseUri = properties.getTypeBaseUri();
+        if (typeBaseUri == null) {
+            return properties.getDefaultType();
+        }
+        String baseUri = typeBaseUri.toString();
+        if (!baseUri.endsWith("/")) {
+            baseUri = baseUri + "/";
+        }
+        return URI.create(baseUri + problemId);
+    }
+
+    private String resolveTitle(String messageKey, String defaultTitle, Locale locale) {
+        return resolveMessage(TITLE_CODE_PREFIX + messageKey, null, defaultTitle, locale);
+    }
+
+    private String resolveDetail(String messageKey, @Nullable String exceptionMessage,
+                                 String defaultDetail, Locale locale) {
+        return resolveMessage(DETAIL_CODE_PREFIX + messageKey, new Object[] { exceptionMessage },
+            defaultDetail, locale);
+    }
+
+    private String resolveMessage(String code, @Nullable Object[] args, String defaultMessage,
+                                  Locale locale) {
+        if (messageSource == null) {
+            return defaultMessage;
+        }
+        return messageSource.getMessage(code, args, defaultMessage, locale);
+    }
+
+    private HttpStatus resolveStatus(int errorType) {
+        switch (errorType) {
+            case RpcErrorType.CLIENT_TIMEOUT:
+                return HttpStatus.GATEWAY_TIMEOUT;
+            case RpcErrorType.SERVER_BUSY:
+            case RpcErrorType.SERVER_CLOSED:
+            case RpcErrorType.SERVER_NOT_FOUND_INVOKER:
+            case RpcErrorType.SERVER_NETWORK:
+            case RpcErrorType.CLIENT_ROUTER:
+            case RpcErrorType.CLIENT_NETWORK:
+                return HttpStatus.SERVICE_UNAVAILABLE;
+            case RpcErrorType.SERVER_SERIALIZE:
+            case RpcErrorType.SERVER_DESERIALIZE:
+            case RpcErrorType.CLIENT_SERIALIZE:
+            case RpcErrorType.CLIENT_DESERIALIZE:
+                return HttpStatus.BAD_GATEWAY;
+            default:
+                return HttpStatus.INTERNAL_SERVER_ERROR;
+        }
+    }
+
+    private String resolveRpcErrorCode(int errorType) {
+        switch (errorType) {
+            case RpcErrorType.SERVER_BUSY:
+                return "server-busy";
+            case RpcErrorType.SERVER_CLOSED:
+                return "server-closed";
+            case RpcErrorType.SERVER_NOT_FOUND_INVOKER:
+                return "server-not-found-invoker";
+            case RpcErrorType.SERVER_SERIALIZE:
+                return "server-serialize";
+            case RpcErrorType.SERVER_DESERIALIZE:
+                return "server-deserialize";
+            case RpcErrorType.SERVER_NETWORK:
+                return "server-network";
+            case RpcErrorType.SERVER_BIZ:
+                return "server-biz";
+            case RpcErrorType.SERVER_FILTER:
+                return "server-filter";
+            case RpcErrorType.SERVER_UNDECLARED_ERROR:
+                return "server-undeclared-error";
+            case RpcErrorType.CLIENT_TIMEOUT:
+                return "client-timeout";
+            case RpcErrorType.CLIENT_ROUTER:
+                return "client-router";
+            case RpcErrorType.CLIENT_SERIALIZE:
+                return "client-serialize";
+            case RpcErrorType.CLIENT_DESERIALIZE:
+                return "client-deserialize";
+            case RpcErrorType.CLIENT_NETWORK:
+                return "client-network";
+            case RpcErrorType.CLIENT_CALL_TYPE:
+                return "client-call-type";
+            case RpcErrorType.CLIENT_FILTER:
+                return "client-filter";
+            case RpcErrorType.CLIENT_UNDECLARED_ERROR:
+                return "client-undeclared-error";
+            default:
+                return "unknown";
+        }
+    }
+
+    private String defaultTitle(int errorType) {
+        switch (errorType) {
+            case RpcErrorType.CLIENT_TIMEOUT:
+                return "RPC request timed out";
+            case RpcErrorType.SERVER_BUSY:
+            case RpcErrorType.SERVER_CLOSED:
+            case RpcErrorType.SERVER_NOT_FOUND_INVOKER:
+            case RpcErrorType.SERVER_NETWORK:
+            case RpcErrorType.CLIENT_ROUTER:
+            case RpcErrorType.CLIENT_NETWORK:
+                return "RPC service unavailable";
+            case RpcErrorType.SERVER_SERIALIZE:
+            case RpcErrorType.SERVER_DESERIALIZE:
+            case RpcErrorType.CLIENT_SERIALIZE:
+            case RpcErrorType.CLIENT_DESERIALIZE:
+                return "RPC message conversion failed";
+            default:
+                return "RPC invocation failed";
+        }
+    }
+
+    private String defaultDetail(Throwable throwable, String defaultTitle) {
+        Throwable rootCause = NestedExceptionUtils.getMostSpecificCause(throwable);
+        String message = rootCause != null ? rootCause.getMessage() : throwable.getMessage();
+        return StringUtils.hasText(message) ? message : defaultTitle;
+    }
+
+    private String buildStackTrace(Throwable throwable) {
+        StringWriter writer = new StringWriter();
+        throwable.printStackTrace(new PrintWriter(writer));
+        return writer.toString();
+    }
+}

--- a/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/problem/SofaProblemDetailProperties.java
+++ b/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/problem/SofaProblemDetailProperties.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.boot.autoconfigure.problem;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.net.URI;
+
+/**
+ * Configuration properties for SOFABoot problem detail support.
+ *
+ * @author OpenAI
+ */
+@ConfigurationProperties("sofa.boot.problem-detail")
+public class SofaProblemDetailProperties {
+
+    /**
+     * Whether problem detail support is enabled.
+     */
+    private boolean enabled            = true;
+
+    /**
+     * Default type URI for unmapped exceptions.
+     */
+    private URI     defaultType        = URI.create("about:blank");
+
+    /**
+     * Base URI used to generate problem type links for SOFA exceptions.
+     */
+    private URI     typeBaseUri        = URI.create("https://sofastack.io/errors/");
+
+    /**
+     * Whether stack traces should be exposed in the response.
+     */
+    private boolean includeStackTrace;
+
+    /**
+     * Whether service metadata should be included in the response.
+     */
+    private boolean includeServiceInfo = true;
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public URI getDefaultType() {
+        return defaultType;
+    }
+
+    public void setDefaultType(URI defaultType) {
+        this.defaultType = defaultType;
+    }
+
+    public URI getTypeBaseUri() {
+        return typeBaseUri;
+    }
+
+    public void setTypeBaseUri(URI typeBaseUri) {
+        this.typeBaseUri = typeBaseUri;
+    }
+
+    public boolean isIncludeStackTrace() {
+        return includeStackTrace;
+    }
+
+    public void setIncludeStackTrace(boolean includeStackTrace) {
+        this.includeStackTrace = includeStackTrace;
+    }
+
+    public boolean isIncludeServiceInfo() {
+        return includeServiceInfo;
+    }
+
+    public void setIncludeServiceInfo(boolean includeServiceInfo) {
+        this.includeServiceInfo = includeServiceInfo;
+    }
+}

--- a/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/problem/SofaRpcExceptionProblemDetailExceptionMapper.java
+++ b/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/problem/SofaRpcExceptionProblemDetailExceptionMapper.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.boot.autoconfigure.problem;
+
+import com.alipay.sofa.rpc.core.exception.SofaRpcException;
+
+import javax.ws.rs.ext.Provider;
+
+/**
+ * JAX-RS mapper for {@link SofaRpcException}.
+ *
+ * @author OpenAI
+ */
+@Provider
+public class SofaRpcExceptionProblemDetailExceptionMapper
+                                                         extends
+                                                         AbstractSofaProblemDetailExceptionMapper<SofaRpcException> {
+
+    public SofaRpcExceptionProblemDetailExceptionMapper(SofaProblemDetailFactory factory) {
+        super(factory);
+    }
+}

--- a/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/problem/SofaRpcRuntimeExceptionProblemDetailExceptionMapper.java
+++ b/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/problem/SofaRpcRuntimeExceptionProblemDetailExceptionMapper.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.boot.autoconfigure.problem;
+
+import com.alipay.sofa.rpc.core.exception.SofaRpcRuntimeException;
+
+import javax.ws.rs.ext.Provider;
+
+/**
+ * JAX-RS mapper for {@link SofaRpcRuntimeException}.
+ *
+ * @author OpenAI
+ */
+@Provider
+public class SofaRpcRuntimeExceptionProblemDetailExceptionMapper
+                                                                extends
+                                                                AbstractSofaProblemDetailExceptionMapper<SofaRpcRuntimeException> {
+
+    public SofaRpcRuntimeExceptionProblemDetailExceptionMapper(SofaProblemDetailFactory factory) {
+        super(factory);
+    }
+}

--- a/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/rpc/SofaBootRpcProperties.java
+++ b/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/rpc/SofaBootRpcProperties.java
@@ -22,6 +22,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.EnvironmentAware;
 import org.springframework.core.env.Environment;
 import org.springframework.util.ObjectUtils;
+import org.springframework.validation.annotation.Validated;
 
 import java.util.HashMap;
 import java.util.List;
@@ -33,6 +34,8 @@ import java.util.Map;
  * @author khotyn
  */
 @ConfigurationProperties("sofa.boot.rpc")
+@Validated
+@ValidSofaBootRpcProperties
 public class SofaBootRpcProperties implements EnvironmentAware {
 
     public static final String  PREFIX     = "sofa.boot.rpc";

--- a/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/rpc/SofaBootRpcPropertiesValidator.java
+++ b/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/rpc/SofaBootRpcPropertiesValidator.java
@@ -1,0 +1,233 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.boot.autoconfigure.rpc;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import org.springframework.util.StringUtils;
+
+import java.math.BigDecimal;
+
+/**
+ * Validator for {@link SofaBootRpcProperties}.
+ *
+ * @author huzijie
+ */
+public class SofaBootRpcPropertiesValidator
+                                           implements
+                                           ConstraintValidator<ValidSofaBootRpcProperties, SofaBootRpcProperties> {
+
+    @Override
+    public boolean isValid(SofaBootRpcProperties value, ConstraintValidatorContext context) {
+        if (value == null) {
+            return true;
+        }
+        context.disableDefaultConstraintViolation();
+        boolean valid = true;
+
+        valid = validatePort(context, valid, "boltPort", value.getBoltPort(),
+            "Bolt 端口必须在 1024 到 65535 之间");
+        valid = validatePort(context, valid, "h2cPort", value.getH2cPort(),
+            "H2C 端口必须在 1024 到 65535 之间");
+        valid = validatePort(context, valid, "restPort", value.getRestPort(),
+            "REST 端口必须在 1024 到 65535 之间");
+        valid = validatePort(context, valid, "dubboPort", value.getDubboPort(),
+            "Dubbo 端口必须在 1024 到 65535 之间");
+        valid = validatePort(context, valid, "httpPort", value.getHttpPort(),
+            "HTTP 端口必须在 1024 到 65535 之间");
+        valid = validatePort(context, valid, "triplePort", value.getTriplePort(),
+            "Triple 端口必须在 1024 到 65535 之间");
+        valid = validatePort(context, valid, "virtualPort", value.getVirtualPort(),
+            "虚拟发布端口必须在 1024 到 65535 之间");
+
+        valid = validatePositiveInteger(context, valid, "boltThreadPoolCoreSize",
+            value.getBoltThreadPoolCoreSize(), "Bolt 线程池核心线程数必须大于 0");
+        valid = validatePositiveInteger(context, valid, "boltThreadPoolMaxSize",
+            value.getBoltThreadPoolMaxSize(), "Bolt 线程池最大线程数必须大于 0");
+        valid = validatePositiveInteger(context, valid, "boltThreadPoolQueueSize",
+            value.getBoltThreadPoolQueueSize(), "Bolt 线程池队列长度必须大于 0");
+        valid = validatePositiveInteger(context, valid, "boltAcceptsSize",
+            value.getBoltAcceptsSize(), "Bolt 允许建立的连接数必须大于 0");
+        valid = validatePositiveInteger(context, valid, "h2cThreadPoolCoreSize",
+            value.getH2cThreadPoolCoreSize(), "H2C 线程池核心线程数必须大于 0");
+        valid = validatePositiveInteger(context, valid, "h2cThreadPoolMaxSize",
+            value.getH2cThreadPoolMaxSize(), "H2C 线程池最大线程数必须大于 0");
+        valid = validatePositiveInteger(context, valid, "h2cThreadPoolQueueSize",
+            value.getH2cThreadPoolQueueSize(), "H2C 线程池队列长度必须大于 0");
+        valid = validatePositiveInteger(context, valid, "h2cAcceptsSize",
+            value.getH2cAcceptsSize(), "H2C 允许建立的连接数必须大于 0");
+        valid = validatePositiveInteger(context, valid, "restIoThreadSize",
+            value.getRestIoThreadSize(), "REST IO 线程数必须大于 0");
+        valid = validatePositiveInteger(context, valid, "restThreadPoolMaxSize",
+            value.getRestThreadPoolMaxSize(), "REST 线程池最大线程数必须大于 0");
+        valid = validatePositiveInteger(context, valid, "restMaxRequestSize",
+            value.getRestMaxRequestSize(), "REST 最大请求体大小必须大于 0");
+        valid = validatePositiveInteger(context, valid, "dubboIoThreadSize",
+            value.getDubboIoThreadSize(), "Dubbo IO 线程数必须大于 0");
+        valid = validatePositiveInteger(context, valid, "dubboThreadPoolMaxSize",
+            value.getDubboThreadPoolMaxSize(), "Dubbo 线程池最大线程数必须大于 0");
+        valid = validatePositiveInteger(context, valid, "dubboAcceptsSize",
+            value.getDubboAcceptsSize(), "Dubbo 允许建立的连接数必须大于 0");
+        valid = validatePositiveInteger(context, valid, "httpThreadPoolCoreSize",
+            value.getHttpThreadPoolCoreSize(), "HTTP 线程池核心线程数必须大于 0");
+        valid = validatePositiveInteger(context, valid, "httpThreadPoolMaxSize",
+            value.getHttpThreadPoolMaxSize(), "HTTP 线程池最大线程数必须大于 0");
+        valid = validatePositiveInteger(context, valid, "httpThreadPoolQueueSize",
+            value.getHttpThreadPoolQueueSize(), "HTTP 线程池队列长度必须大于 0");
+        valid = validatePositiveInteger(context, valid, "httpAcceptsSize",
+            value.getHttpAcceptsSize(), "HTTP 允许建立的连接数必须大于 0");
+        valid = validatePositiveInteger(context, valid, "tripleThreadPoolCoreSize",
+            value.getTripleThreadPoolCoreSize(), "Triple 线程池核心线程数必须大于 0");
+        valid = validatePositiveInteger(context, valid, "tripleThreadPoolMaxSize",
+            value.getTripleThreadPoolMaxSize(), "Triple 线程池最大线程数必须大于 0");
+        valid = validatePositiveInteger(context, valid, "tripleThreadPoolQueueSize",
+            value.getTripleThreadPoolQueueSize(), "Triple 线程池队列长度必须大于 0");
+        valid = validatePositiveInteger(context, valid, "tripleAcceptsSize",
+            value.getTripleAcceptsSize(), "Triple 允许建立的连接数必须大于 0");
+        valid = validatePositiveInteger(context, valid, "consumerRepeatedReferenceLimit",
+            value.getConsumerRepeatedReferenceLimit(), "重复引用限制必须大于 0");
+
+        valid = validateBooleanString(context, valid, "aftRegulationEffective",
+            value.getAftRegulationEffective(), "AFT 单机故障剔除开关必须为 true 或 false");
+        valid = validateBooleanString(context, valid, "aftDegradeEffective",
+            value.getAftDegradeEffective(), "AFT 降级开关必须为 true 或 false");
+        valid = validateBooleanString(context, valid, "restTelnet", value.getRestTelnet(),
+            "REST telnet 开关必须为 true 或 false");
+        valid = validateBooleanString(context, valid, "restDaemon", value.getRestDaemon(),
+            "REST daemon 开关必须为 true 或 false");
+
+        valid = validatePositiveInteger(context, valid, "aftTimeWindow", value.getAftTimeWindow(),
+            "AFT 时间窗口必须大于 0");
+        valid = validatePositiveInteger(context, valid, "aftLeastWindowCount",
+            value.getAftLeastWindowCount(), "AFT 最小调用次数必须大于 0");
+        valid = validatePositiveDecimal(context, valid, "aftLeastWindowExceptionRateMultiple",
+            value.getAftLeastWindowExceptionRateMultiple(), "AFT 最小异常率倍数必须大于 0");
+        valid = validateRange(context, valid, "aftDegradeLeastWeight",
+            value.getAftDegradeLeastWeight(), 0, 100, "降级最小权重必须在 0 到 100 之间");
+        valid = validatePositiveInteger(context, valid, "aftDegradeMaxIpCount",
+            value.getAftDegradeMaxIpCount(), "AFT 最大降级 IP 数必须大于 0");
+        valid = validateDecimalRange(context, valid, "aftWeightDegradeRate",
+            value.getAftWeightDegradeRate(), BigDecimal.ZERO, false, BigDecimal.ONE, true,
+            "降级速率必须大于 0 且不能大于 1");
+        valid = validatePositiveDecimal(context, valid, "aftWeightRecoverRate",
+            value.getAftWeightRecoverRate(), "恢复速率必须大于 0");
+
+        return valid;
+    }
+
+    private boolean validatePort(ConstraintValidatorContext context, boolean valid,
+                                 String fieldName, String rawValue, String message) {
+        return validateRange(context, valid, fieldName, rawValue, 1024, 65535, message);
+    }
+
+    private boolean validatePositiveInteger(ConstraintValidatorContext context, boolean valid,
+                                            String fieldName, String rawValue, String message) {
+        if (!StringUtils.hasText(rawValue)) {
+            return valid;
+        }
+        Integer parsedValue = parseInteger(rawValue);
+        if (parsedValue == null || parsedValue <= 0) {
+            addViolation(context, fieldName, message);
+            return false;
+        }
+        return valid;
+    }
+
+    private boolean validateRange(ConstraintValidatorContext context, boolean valid,
+                                  String fieldName, String rawValue, int min, int max,
+                                  String message) {
+        if (!StringUtils.hasText(rawValue)) {
+            return valid;
+        }
+        Integer parsedValue = parseInteger(rawValue);
+        if (parsedValue == null || parsedValue < min || parsedValue > max) {
+            addViolation(context, fieldName, message);
+            return false;
+        }
+        return valid;
+    }
+
+    private boolean validatePositiveDecimal(ConstraintValidatorContext context, boolean valid,
+                                            String fieldName, String rawValue, String message) {
+        if (!StringUtils.hasText(rawValue)) {
+            return valid;
+        }
+        BigDecimal parsedValue = parseDecimal(rawValue);
+        if (parsedValue == null || parsedValue.compareTo(BigDecimal.ZERO) <= 0) {
+            addViolation(context, fieldName, message);
+            return false;
+        }
+        return valid;
+    }
+
+    private boolean validateDecimalRange(ConstraintValidatorContext context, boolean valid,
+                                         String fieldName, String rawValue, BigDecimal min,
+                                         boolean minInclusive, BigDecimal max,
+                                         boolean maxInclusive, String message) {
+        if (!StringUtils.hasText(rawValue)) {
+            return valid;
+        }
+        BigDecimal parsedValue = parseDecimal(rawValue);
+        if (parsedValue == null) {
+            addViolation(context, fieldName, message);
+            return false;
+        }
+
+        boolean underMin = minInclusive ? parsedValue.compareTo(min) < 0 : parsedValue
+            .compareTo(min) <= 0;
+        boolean overMax = maxInclusive ? parsedValue.compareTo(max) > 0 : parsedValue
+            .compareTo(max) >= 0;
+        if (underMin || overMax) {
+            addViolation(context, fieldName, message);
+            return false;
+        }
+        return valid;
+    }
+
+    private boolean validateBooleanString(ConstraintValidatorContext context, boolean valid,
+                                          String fieldName, String rawValue, String message) {
+        if (!StringUtils.hasText(rawValue)) {
+            return valid;
+        }
+        if (!"true".equalsIgnoreCase(rawValue) && !"false".equalsIgnoreCase(rawValue)) {
+            addViolation(context, fieldName, message);
+            return false;
+        }
+        return valid;
+    }
+
+    private Integer parseInteger(String rawValue) {
+        try {
+            return Integer.valueOf(rawValue);
+        } catch (NumberFormatException ex) {
+            return null;
+        }
+    }
+
+    private BigDecimal parseDecimal(String rawValue) {
+        try {
+            return new BigDecimal(rawValue);
+        } catch (NumberFormatException ex) {
+            return null;
+        }
+    }
+
+    private void addViolation(ConstraintValidatorContext context, String fieldName, String message) {
+        context.buildConstraintViolationWithTemplate(message).addPropertyNode(fieldName)
+            .addConstraintViolation();
+    }
+}

--- a/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/rpc/ValidSofaBootRpcProperties.java
+++ b/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/rpc/ValidSofaBootRpcProperties.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.boot.autoconfigure.rpc;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Class-level constraint for {@link SofaBootRpcProperties}.
+ *
+ * @author huzijie
+ */
+@Documented
+@Constraint(validatedBy = SofaBootRpcPropertiesValidator.class)
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidSofaBootRpcProperties {
+
+    String message() default "SOFA RPC 配置不合法";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/runtime/SofaRuntimeProperties.java
+++ b/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/runtime/SofaRuntimeProperties.java
@@ -17,7 +17,10 @@
 package com.alipay.sofa.boot.autoconfigure.runtime;
 
 import com.alipay.sofa.boot.constant.SofaBootConstants;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.PositiveOrZero;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -29,6 +32,7 @@ import java.util.List;
  * @author huzijie
  */
 @ConfigurationProperties("sofa.boot.runtime")
+@Validated
 public class SofaRuntimeProperties {
 
     /**
@@ -80,11 +84,13 @@ public class SofaRuntimeProperties {
     /**
      * Custom async init executor core size.
      */
+    @PositiveOrZero(message = "异步初始化线程池核心线程数不能小于 0")
     private int          asyncInitExecutorCoreSize       = SofaBootConstants.CPU_CORE + 1;
 
     /**
      * Custom async init executor max size.
      */
+    @PositiveOrZero(message = "异步初始化线程池最大线程数不能小于 0")
     private int          asyncInitExecutorMaxSize        = SofaBootConstants.CPU_CORE + 1;
 
     /**
@@ -199,5 +205,10 @@ public class SofaRuntimeProperties {
 
     public void setServiceCanBeDuplicate(boolean serviceCanBeDuplicate) {
         this.serviceCanBeDuplicate = serviceCanBeDuplicate;
+    }
+
+    @AssertTrue(message = "异步初始化线程池最大线程数不能小于核心线程数")
+    public boolean isAsyncInitExecutorPoolSizeValid() {
+        return asyncInitExecutorMaxSize >= asyncInitExecutorCoreSize;
     }
 }

--- a/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/tracer/SofaTracerProperties.java
+++ b/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/tracer/SofaTracerProperties.java
@@ -19,7 +19,11 @@ package com.alipay.sofa.boot.autoconfigure.tracer;
 import com.alipay.common.tracer.core.appender.file.TimedRollingFileAppender;
 import com.alipay.common.tracer.core.configuration.SofaTracerConfiguration;
 import com.alipay.common.tracer.core.reporter.stat.manager.SofaTracerStatisticReporterManager;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Pattern;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -34,11 +38,13 @@ import static com.alipay.common.tracer.core.configuration.SofaTracerConfiguratio
  * @since 2018/04/30
  */
 @ConfigurationProperties("sofa.boot.tracer")
+@Validated
 public class SofaTracerProperties {
 
     /**
      * Disable digest log.
      */
+    @Pattern(regexp = "^(?i:true|false)$", message = "disableDigestLog 必须为 true 或 false")
     private String              disableDigestLog          = "false";
 
     /**
@@ -54,17 +60,20 @@ public class SofaTracerProperties {
     /**
      * Tracer's global log retention days configuration.
      */
+    @Pattern(regexp = "^\\d+$", message = "日志保留天数必须为非负整数")
     private String              tracerGlobalLogReserveDay = String.valueOf(DEFAULT_LOG_RESERVE_DAY);
 
     /**
      * The interval for printing the stat log.
      */
+    @Pattern(regexp = "^\\d+$", message = "统计日志打印间隔必须为非负整数")
     private String              statLogInterval           = String
                                                               .valueOf(SofaTracerStatisticReporterManager.DEFAULT_CYCLE_SECONDS);
 
     /**
      * Threshold, the length of the service transparent field
      */
+    @Pattern(regexp = "^\\d+$", message = "透传字段长度阈值必须为非负整数")
     private String              baggageMaxLength          = String
                                                               .valueOf(SofaTracerConfiguration.PEN_ATTRS_LENGTH_TRESHOLD);
 
@@ -76,6 +85,8 @@ public class SofaTracerProperties {
     /**
      * Sampling policy percentage.
      */
+    @DecimalMin(value = "0.0", message = "采样率不能小于 0")
+    @DecimalMax(value = "100.0", message = "采样率不能大于 100")
     private float               samplerPercentage         = 100;
 
     /**

--- a/sofa-boot-project/sofa-boot-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/sofa-boot-project/sofa-boot-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,6 +1,7 @@
 com.alipay.sofa.boot.autoconfigure.runtime.SofaRuntimeAutoConfiguration
 com.alipay.sofa.boot.autoconfigure.isle.SofaModuleAutoConfiguration
 com.alipay.sofa.boot.autoconfigure.rpc.SofaRpcAutoConfiguration
+com.alipay.sofa.boot.autoconfigure.problem.SofaProblemDetailAutoConfiguration
 com.alipay.sofa.boot.autoconfigure.tracer.SofaTracerAutoConfiguration
 com.alipay.sofa.boot.autoconfigure.tracer.datasource.DataSourceAutoConfiguration
 com.alipay.sofa.boot.autoconfigure.tracer.zipkin.ZipkinAutoConfiguration

--- a/sofa-boot-project/sofa-boot-autoconfigure/src/test/java/com/alipay/sofa/boot/autoconfigure/isle/SofaModuleAutoConfigurationTests.java
+++ b/sofa-boot-project/sofa-boot-autoconfigure/src/test/java/com/alipay/sofa/boot/autoconfigure/isle/SofaModuleAutoConfigurationTests.java
@@ -36,6 +36,7 @@ import org.junit.jupiter.api.condition.JRE;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.core.NestedExceptionUtils;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -151,6 +152,17 @@ public class SofaModuleAutoConfigurationTests {
                     assertThat(threadPoolExecutor.getCorePoolSize()).isEqualTo(SofaBootConstants.CPU_CORE * 2);
                     assertThat(threadPoolExecutor.getConfig().getTaskTimeout()).isEqualTo(10);
                     assertThat(threadPoolExecutor.getConfig().getPeriod()).isEqualTo(20);
+                });
+    }
+
+    @Test
+    void invalidParallelRefreshConfigShouldFailFast() {
+        this.contextRunner
+                .withPropertyValues("sofa.boot.isle.parallelRefreshPoolSizeFactor=0")
+                .run((context) -> {
+                    assertThat(context).hasFailed();
+                    assertThat(NestedExceptionUtils.getMostSpecificCause(context.getStartupFailure()).getMessage())
+                            .contains("模块并行刷新线程池倍率必须大于 0");
                 });
     }
 

--- a/sofa-boot-project/sofa-boot-autoconfigure/src/test/java/com/alipay/sofa/boot/autoconfigure/problem/SofaProblemDetailAutoConfigurationTests.java
+++ b/sofa-boot-project/sofa-boot-autoconfigure/src/test/java/com/alipay/sofa/boot/autoconfigure/problem/SofaProblemDetailAutoConfigurationTests.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.boot.autoconfigure.problem;
+
+import com.alipay.sofa.rpc.core.exception.RpcErrorType;
+import com.alipay.sofa.rpc.core.exception.SofaRpcException;
+import com.alipay.sofa.rpc.config.JAXRSProviderManager;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import javax.ws.rs.core.Response;
+import java.util.LinkedHashSet;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link SofaProblemDetailAutoConfiguration}.
+ *
+ * @author OpenAI
+ */
+public class SofaProblemDetailAutoConfigurationTests {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+                                                             .withConfiguration(AutoConfigurations
+                                                                 .of(SofaProblemDetailAutoConfiguration.class));
+
+    @AfterEach
+    void clearJaxrsProviders() {
+        for (Object provider : new LinkedHashSet<Object>(
+            JAXRSProviderManager.getCustomProviderInstances())) {
+            JAXRSProviderManager.removeCustomProviderInstance(provider);
+        }
+    }
+
+    @Test
+    void defaultBeansCreatedAndJaxrsProvidersRegistered() {
+        this.contextRunner.withPropertyValues("spring.application.name=problem-app").run(context -> {
+            assertThat(context).hasSingleBean(SofaProblemDetailFactory.class);
+            assertThat(context).hasSingleBean(SofaRpcExceptionProblemDetailExceptionMapper.class);
+            assertThat(context)
+                .hasSingleBean(SofaRpcRuntimeExceptionProblemDetailExceptionMapper.class);
+            assertThat(context)
+                .hasSingleBean(SofaBootRpcRuntimeExceptionProblemDetailExceptionMapper.class);
+            assertThat(JAXRSProviderManager.getCustomProviderInstances()).hasSize(3);
+        });
+    }
+
+    @Test
+    void disabledConfigurationShouldBackOff() {
+        this.contextRunner.withPropertyValues("sofa.boot.problem-detail.enabled=false")
+            .run(context -> {
+                assertThat(context).doesNotHaveBean(SofaProblemDetailFactory.class);
+                assertThat(context)
+                    .doesNotHaveBean(SofaRpcExceptionProblemDetailExceptionMapper.class);
+                assertThat(JAXRSProviderManager.getCustomProviderInstances()).isEmpty();
+            });
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void jaxrsMapperShouldRenderProblemJsonShape() {
+        this.contextRunner.withPropertyValues("spring.application.name=problem-app").run(context -> {
+            SofaRpcExceptionProblemDetailExceptionMapper mapper = context
+                .getBean(SofaRpcExceptionProblemDetailExceptionMapper.class);
+            Response response = mapper.toResponse(new SofaRpcException(RpcErrorType.CLIENT_TIMEOUT,
+                "provider timeout"));
+
+            assertThat(response.getStatus()).isEqualTo(504);
+            assertThat(response.getMediaType().toString()).isEqualTo("application/problem+json");
+
+            Map<String, Object> entity = (Map<String, Object>) response.getEntity();
+            assertThat(entity.get("type"))
+                .isEqualTo("https://sofastack.io/errors/sofa-rpc/client-timeout");
+            assertThat(entity.get("title")).isEqualTo("RPC request timed out");
+            assertThat(entity.get("detail")).isEqualTo("provider timeout");
+            assertThat(entity.get("errorCode")).isEqualTo("client-timeout");
+            assertThat(entity.get("errorType")).isEqualTo(RpcErrorType.CLIENT_TIMEOUT);
+            assertThat(entity.get("service")).isEqualTo("problem-app");
+        });
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void stackTraceCanBeIncludedWhenEnabled() {
+        this.contextRunner
+            .withPropertyValues("sofa.boot.problem-detail.include-stack-trace=true")
+            .run(context -> {
+                SofaRpcExceptionProblemDetailExceptionMapper mapper = context
+                    .getBean(SofaRpcExceptionProblemDetailExceptionMapper.class);
+                Response response = mapper.toResponse(new SofaRpcException(
+                    RpcErrorType.CLIENT_UNDECLARED_ERROR, "unexpected"));
+
+                Map<String, Object> entity = (Map<String, Object>) response.getEntity();
+                assertThat(entity).containsKey("stackTrace");
+                assertThat(entity.get("stackTrace").toString()).contains("SofaRpcException");
+            });
+    }
+}

--- a/sofa-boot-project/sofa-boot-autoconfigure/src/test/java/com/alipay/sofa/boot/autoconfigure/problem/SofaProblemDetailMvcAutoConfigurationTests.java
+++ b/sofa-boot-project/sofa-boot-autoconfigure/src/test/java/com/alipay/sofa/boot/autoconfigure/problem/SofaProblemDetailMvcAutoConfigurationTests.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.boot.autoconfigure.problem;
+
+import com.alipay.sofa.rpc.core.exception.RpcErrorType;
+import com.alipay.sofa.rpc.core.exception.SofaRpcException;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.http.HttpMessageConvertersAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.servlet.DispatcherServletAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.servlet.WebMvcAutoConfiguration;
+import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
+import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
+import org.springframework.boot.web.servlet.context.AnnotationConfigServletWebServerApplicationContext;
+import org.springframework.context.MessageSource;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.support.StaticMessageSource;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * MVC tests for {@link SofaProblemDetailAutoConfiguration}.
+ *
+ * @author OpenAI
+ */
+public class SofaProblemDetailMvcAutoConfigurationTests {
+
+    private final WebApplicationContextRunner contextRunner = new WebApplicationContextRunner(
+        AnnotationConfigServletWebServerApplicationContext::new)
+                                                                   .withUserConfiguration(
+                                                                       ServletConfiguration.class,
+                                                                       ProblemController.class)
+                                                                   .withConfiguration(AutoConfigurations
+                                                                       .of(DispatcherServletAutoConfiguration.class,
+                                                                           HttpMessageConvertersAutoConfiguration.class,
+                                                                           WebMvcAutoConfiguration.class,
+                                                                           SofaProblemDetailAutoConfiguration.class));
+
+    @Test
+    void mvcHandlerShouldReturnProblemDetailResponse() {
+        this.contextRunner.withPropertyValues("spring.application.name=problem-app")
+            .run(context -> {
+                mockMvc(context).perform(get("/rpc-timeout")).andExpect(status().isGatewayTimeout())
+                    .andExpect(content().contentType("application/problem+json"))
+                    .andExpect(jsonPath("$.type")
+                        .value("https://sofastack.io/errors/sofa-rpc/client-timeout"))
+                    .andExpect(jsonPath("$.title").value("RPC request timed out"))
+                    .andExpect(jsonPath("$.detail").value("provider timeout"))
+                    .andExpect(jsonPath("$.instance").value("/rpc-timeout"))
+                    .andExpect(jsonPath("$.errorCode").value("client-timeout"))
+                    .andExpect(jsonPath("$.errorType").value(RpcErrorType.CLIENT_TIMEOUT))
+                    .andExpect(jsonPath("$.service").value("problem-app"));
+            });
+    }
+
+    @Test
+    void mvcHandlerShouldSupportI18nMessages() {
+        this.contextRunner
+            .withUserConfiguration(ChineseProblemDetailMessageSourceConfiguration.class)
+            .run(context -> {
+                mockMvc(context).perform(get("/rpc-timeout").header("Accept-Language", "zh-CN"))
+                    .andExpect(status().isGatewayTimeout())
+                    .andExpect(jsonPath("$.title").value("RPC 请求超时"))
+                    .andExpect(jsonPath("$.detail").value("远程调用超时: provider timeout"));
+            });
+    }
+
+    @Test
+    void customAdviceShouldWinBeforeDefaultProblemDetailHandler() {
+        this.contextRunner.withUserConfiguration(CustomRpcExceptionHandlerConfiguration.class)
+            .run(context -> {
+                mockMvc(context).perform(get("/rpc-timeout")).andExpect(status().isIAmATeapot())
+                    .andExpect(jsonPath("$.message").value("custom-handler"));
+            });
+    }
+
+    @Test
+    void stackTraceShouldBeExposedWhenConfigured() {
+        this.contextRunner
+            .withPropertyValues("sofa.boot.problem-detail.include-stack-trace=true")
+            .run(context -> {
+                mockMvc(context).perform(get("/rpc-timeout"))
+                    .andExpect(status().isGatewayTimeout())
+                    .andExpect(jsonPath("$.stackTrace").exists());
+            });
+    }
+
+    private MockMvc mockMvc(WebApplicationContext context) {
+        return MockMvcBuilders.webAppContextSetup(context).build();
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    static class ServletConfiguration {
+
+        @Bean
+        TomcatServletWebServerFactory tomcat() {
+            return new TomcatServletWebServerFactory(0);
+        }
+    }
+
+    @RestController
+    static class ProblemController {
+
+        @GetMapping("/rpc-timeout")
+        String rpcTimeout() {
+            throw new SofaRpcException(RpcErrorType.CLIENT_TIMEOUT, "provider timeout");
+        }
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    static class ChineseProblemDetailMessageSourceConfiguration {
+
+        @Bean
+        MessageSource messageSource() {
+            StaticMessageSource messageSource = new StaticMessageSource();
+            messageSource.addMessage(
+                "sofa.boot.problem-detail.title.sofa-rpc.client-timeout",
+                java.util.Locale.SIMPLIFIED_CHINESE, "RPC 请求超时");
+            messageSource.addMessage(
+                "sofa.boot.problem-detail.detail.sofa-rpc.client-timeout",
+                java.util.Locale.SIMPLIFIED_CHINESE, "远程调用超时: {0}");
+            return messageSource;
+        }
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    static class CustomRpcExceptionHandlerConfiguration {
+
+        @RestControllerAdvice
+        @Order(Ordered.HIGHEST_PRECEDENCE)
+        static class CustomRpcExceptionHandler {
+
+            @ExceptionHandler(SofaRpcException.class)
+            org.springframework.http.ResponseEntity<java.util.Map<String, Object>> handle(
+                                                                                             SofaRpcException exception) {
+                java.util.Map<String, Object> body = new java.util.LinkedHashMap<String, Object>();
+                body.put("message", "custom-handler");
+                return org.springframework.http.ResponseEntity.status(418).body(body);
+            }
+        }
+    }
+}

--- a/sofa-boot-project/sofa-boot-autoconfigure/src/test/java/com/alipay/sofa/boot/autoconfigure/rpc/SofaBootRpcPropertiesValidatorTests.java
+++ b/sofa-boot-project/sofa-boot-autoconfigure/src/test/java/com/alipay/sofa/boot/autoconfigure/rpc/SofaBootRpcPropertiesValidatorTests.java
@@ -1,0 +1,214 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.boot.autoconfigure.rpc;
+
+import jakarta.validation.ConstraintValidatorContext;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.env.StandardEnvironment;
+
+import java.lang.reflect.Method;
+import java.math.BigDecimal;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+/**
+ * Tests for {@link SofaBootRpcPropertiesValidator}.
+ *
+ * @author huzijie
+ */
+public class SofaBootRpcPropertiesValidatorTests {
+
+    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+    @Test
+    void nullPropertiesShouldBeValid() {
+        SofaBootRpcPropertiesValidator propertiesValidator = new SofaBootRpcPropertiesValidator();
+        ConstraintValidatorContext context = mock(ConstraintValidatorContext.class);
+
+        assertThat(propertiesValidator.isValid(null, context)).isTrue();
+        verifyNoInteractions(context);
+    }
+
+    @Test
+    void emptyPropertiesShouldBeValid() {
+        Set<ConstraintViolation<SofaBootRpcProperties>> violations = validator
+            .validate(newProperties());
+
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    void boundaryValuesShouldBeValid() {
+        SofaBootRpcProperties properties = newProperties();
+        properties.setBoltPort("1024");
+        properties.setVirtualPort("65535");
+        properties.setBoltThreadPoolCoreSize("1");
+        properties.setBoltThreadPoolMaxSize("1");
+        properties.setBoltThreadPoolQueueSize("1");
+        properties.setBoltAcceptsSize("1");
+        properties.setConsumerRepeatedReferenceLimit("1");
+        properties.setAftRegulationEffective("true");
+        properties.setAftDegradeEffective("FALSE");
+        properties.setRestTelnet("true");
+        properties.setRestDaemon("false");
+        properties.setAftTimeWindow("1");
+        properties.setAftLeastWindowCount("1");
+        properties.setAftLeastWindowExceptionRateMultiple("0.1");
+        properties.setAftDegradeLeastWeight("100");
+        properties.setAftDegradeMaxIpCount("1");
+        properties.setAftWeightDegradeRate("1");
+        properties.setAftWeightRecoverRate("0.1");
+
+        Set<ConstraintViolation<SofaBootRpcProperties>> violations = validator.validate(properties);
+
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    void invalidTextValuesShouldProduceFieldViolations() {
+        SofaBootRpcProperties properties = newProperties();
+        properties.setBoltPort("abc");
+        properties.setBoltThreadPoolMaxSize("abc");
+        properties.setAftRegulationEffective("enabled");
+        properties.setRestDaemon("daemon");
+        properties.setAftLeastWindowExceptionRateMultiple("NaN");
+        properties.setAftWeightDegradeRate("fast");
+        properties.setAftWeightRecoverRate("slow");
+
+        Map<String, String> violations = messagesByField(validator.validate(properties));
+
+        assertThat(violations).containsEntry("boltPort", "Bolt 端口必须在 1024 到 65535 之间")
+            .containsEntry("boltThreadPoolMaxSize", "Bolt 线程池最大线程数必须大于 0")
+            .containsEntry("aftRegulationEffective", "AFT 单机故障剔除开关必须为 true 或 false")
+            .containsEntry("restDaemon", "REST daemon 开关必须为 true 或 false")
+            .containsEntry("aftLeastWindowExceptionRateMultiple", "AFT 最小异常率倍数必须大于 0")
+            .containsEntry("aftWeightDegradeRate", "降级速率必须大于 0 且不能大于 1")
+            .containsEntry("aftWeightRecoverRate", "恢复速率必须大于 0");
+    }
+
+    @Test
+    void outOfRangeValuesShouldProduceFieldViolations() {
+        SofaBootRpcProperties properties = newProperties();
+        properties.setBoltPort("80");
+        properties.setVirtualPort("65536");
+        properties.setBoltThreadPoolCoreSize("0");
+        properties.setConsumerRepeatedReferenceLimit("0");
+        properties.setAftTimeWindow("0");
+        properties.setAftDegradeLeastWeight("-1");
+        properties.setAftWeightDegradeRate("0");
+        properties.setAftWeightRecoverRate("0");
+
+        Map<String, String> violations = messagesByField(validator.validate(properties));
+
+        assertThat(violations).containsEntry("boltPort", "Bolt 端口必须在 1024 到 65535 之间")
+            .containsEntry("virtualPort", "虚拟发布端口必须在 1024 到 65535 之间")
+            .containsEntry("boltThreadPoolCoreSize", "Bolt 线程池核心线程数必须大于 0")
+            .containsEntry("consumerRepeatedReferenceLimit", "重复引用限制必须大于 0")
+            .containsEntry("aftTimeWindow", "AFT 时间窗口必须大于 0")
+            .containsEntry("aftDegradeLeastWeight", "降级最小权重必须在 0 到 100 之间")
+            .containsEntry("aftWeightDegradeRate", "降级速率必须大于 0 且不能大于 1")
+            .containsEntry("aftWeightRecoverRate", "恢复速率必须大于 0");
+    }
+
+    @Test
+    void decimalValuesAboveMaxShouldBeRejected() {
+        SofaBootRpcProperties properties = newProperties();
+        properties.setAftWeightDegradeRate("1.1");
+
+        Map<String, String> violations = messagesByField(validator.validate(properties));
+
+        assertThat(violations).containsEntry("aftWeightDegradeRate", "降级速率必须大于 0 且不能大于 1");
+    }
+
+    @Test
+    void blankValuesShouldBeIgnored() {
+        SofaBootRpcProperties properties = newProperties();
+        properties.setBoltPort(" ");
+        properties.setAftRegulationEffective(" ");
+        properties.setAftWeightDegradeRate(" ");
+        properties.setAftWeightRecoverRate(" ");
+
+        Set<ConstraintViolation<SofaBootRpcProperties>> violations = validator.validate(properties);
+
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    void invalidDecimalFormatShouldBeRejected() {
+        SofaBootRpcProperties properties = newProperties();
+        properties.setAftWeightDegradeRate(".");
+        properties.setAftWeightRecoverRate(".");
+
+        Map<String, String> violations = messagesByField(validator.validate(properties));
+
+        assertThat(violations).containsEntry("aftWeightDegradeRate", "降级速率必须大于 0 且不能大于 1")
+            .containsEntry("aftWeightRecoverRate", "恢复速率必须大于 0");
+    }
+
+    @Test
+    void inclusiveAndExclusiveDecimalBoundariesShouldBeHandled() throws Exception {
+        SofaBootRpcPropertiesValidator propertiesValidator = new SofaBootRpcPropertiesValidator();
+        ConstraintValidatorContext context = mock(ConstraintValidatorContext.class,
+            RETURNS_DEEP_STUBS);
+
+        assertThat(
+            invokeValidateDecimalRange(propertiesValidator, context, "-0.1", BigDecimal.ZERO, true,
+                BigDecimal.ONE, false)).isFalse();
+        assertThat(
+            invokeValidateDecimalRange(propertiesValidator, context, "0", BigDecimal.ZERO, true,
+                BigDecimal.ONE, false)).isTrue();
+        assertThat(
+            invokeValidateDecimalRange(propertiesValidator, context, "1", BigDecimal.ZERO, true,
+                BigDecimal.ONE, false)).isFalse();
+    }
+
+    private SofaBootRpcProperties newProperties() {
+        SofaBootRpcProperties properties = new SofaBootRpcProperties();
+        properties.setEnvironment(new StandardEnvironment());
+        return properties;
+    }
+
+    private boolean invokeValidateDecimalRange(SofaBootRpcPropertiesValidator propertiesValidator,
+                                               ConstraintValidatorContext context, String rawValue,
+                                               BigDecimal min, boolean minInclusive,
+                                               BigDecimal max, boolean maxInclusive)
+                                                                                    throws Exception {
+        Method method = SofaBootRpcPropertiesValidator.class.getDeclaredMethod(
+            "validateDecimalRange", ConstraintValidatorContext.class, boolean.class, String.class,
+            String.class, BigDecimal.class, boolean.class, BigDecimal.class, boolean.class,
+            String.class);
+        method.setAccessible(true);
+        return (boolean) method.invoke(propertiesValidator, context, true, "field", rawValue, min,
+            minInclusive, max, maxInclusive, "message");
+    }
+
+    private Map<String, String> messagesByField(
+                                               Set<ConstraintViolation<SofaBootRpcProperties>> violations) {
+        return violations.stream().collect(Collectors.toMap(
+            violation -> violation.getPropertyPath().toString(), ConstraintViolation::getMessage,
+            (left, right) -> left));
+    }
+}

--- a/sofa-boot-project/sofa-boot-autoconfigure/src/test/java/com/alipay/sofa/boot/autoconfigure/rpc/SofaRpcAutoConfigurationTests.java
+++ b/sofa-boot-project/sofa-boot-autoconfigure/src/test/java/com/alipay/sofa/boot/autoconfigure/rpc/SofaRpcAutoConfigurationTests.java
@@ -46,6 +46,7 @@ import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.NestedExceptionUtils;
 
 import javax.ws.rs.client.ClientRequestFilter;
 import javax.ws.rs.client.ClientResponseFilter;
@@ -212,6 +213,18 @@ public class SofaRpcAutoConfigurationTests {
                     assertThat(faultToleranceConfig.getWeightRecoverRate()).isEqualTo(3.0);
                     assertThat(faultToleranceConfig.getDegradeLeastWeight()).isEqualTo(2);
                     assertThat(faultToleranceConfig.getDegradeMaxIpCount()).isEqualTo(3);
+                });
+    }
+
+    @Test
+    void invalidRpcPropertiesShouldFailFast() {
+        this.contextRunner.withPropertyValues("sofa.boot.rpc.boltPort=80",
+                        "sofa.boot.rpc.aftDegradeLeastWeight=-10")
+                .run(context -> {
+                    assertThat(context).hasFailed();
+                    assertThat(NestedExceptionUtils.getMostSpecificCause(context.getStartupFailure()).getMessage())
+                            .contains("Bolt 端口必须在 1024 到 65535 之间")
+                            .contains("降级最小权重必须在 0 到 100 之间");
                 });
     }
 

--- a/sofa-boot-project/sofa-boot-autoconfigure/src/test/java/com/alipay/sofa/boot/autoconfigure/runtime/SofaRuntimeAutoConfigurationTests.java
+++ b/sofa-boot-project/sofa-boot-autoconfigure/src/test/java/com/alipay/sofa/boot/autoconfigure/runtime/SofaRuntimeAutoConfigurationTests.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.condition.JRE;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.core.NestedExceptionUtils;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -127,6 +128,18 @@ public class SofaRuntimeAutoConfigurationTests {
                     assertThat(threadPoolExecutor).isInstanceOf(ThreadPoolExecutor.class);
                     assertThat(((ThreadPoolExecutor) threadPoolExecutor).getCorePoolSize()).isEqualTo(10);
                     assertThat(((ThreadPoolExecutor) threadPoolExecutor).getMaximumPoolSize()).isEqualTo(10);
+                });
+    }
+
+    @Test
+    public void invalidAsyncInitExecutorConfigShouldFailFast() {
+        this.contextRunner
+                .withPropertyValues("sofa.boot.runtime.asyncInitExecutorCoreSize=10")
+                .withPropertyValues("sofa.boot.runtime.asyncInitExecutorMaxSize=5")
+                .run((context) -> {
+                    assertThat(context).hasFailed();
+                    assertThat(NestedExceptionUtils.getMostSpecificCause(context.getStartupFailure()).getMessage())
+                            .contains("异步初始化线程池最大线程数不能小于核心线程数");
                 });
     }
 

--- a/sofa-boot-project/sofa-boot-autoconfigure/src/test/java/com/alipay/sofa/boot/autoconfigure/tracer/SofaTracerAutoConfigurationTests.java
+++ b/sofa-boot-project/sofa-boot-autoconfigure/src/test/java/com/alipay/sofa/boot/autoconfigure/tracer/SofaTracerAutoConfigurationTests.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.core.NestedExceptionUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -57,6 +58,17 @@ public class SofaTracerAutoConfigurationTests {
     public void withoutSpanReportListenerHolder() {
         this.contextRunner
                 .run((context) -> assertThat(context.getBean("sofaTracerSpanReportListener").toString()).isEqualTo("null"));
+    }
+
+    @Test
+    public void invalidTracerPropertiesShouldFailFast() {
+        this.contextRunner
+                .withPropertyValues("sofa.boot.tracer.samplerPercentage=101")
+                .run((context) -> {
+                    assertThat(context).hasFailed();
+                    assertThat(NestedExceptionUtils.getMostSpecificCause(context.getStartupFailure()).getMessage())
+                            .contains("采样率不能大于 100");
+                });
     }
 
     static class SampleSpanReportListener implements SpanReportListener {

--- a/sofa-boot-project/sofaboot-dependencies/pom.xml
+++ b/sofa-boot-project/sofaboot-dependencies/pom.xml
@@ -122,6 +122,12 @@
             </dependency>
 
             <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-starter-validation</artifactId>
+                <version>${spring.boot.version}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>com.alipay.sofa</groupId>
                 <artifactId>sofa-boot</artifactId>
                 <version>${sofa.boot.version}</version>


### PR DESCRIPTION
This PR adds ProblemDetail support in sofa-boot-autoconfigure to standardize REST and SOFA RPC REST error responses based on RFC 7807.Related issue #1403

It includes:

- Adding SofaProblemDetailAutoConfiguration and related configuration properties under sofa.boot.problem-detail.*
- Introducing a shared SofaProblemDetailFactory to centralize exception-to-ProblemDetail mapping
- Adding a Spring MVC @RestControllerAdvice to render SOFA exceptions as application/problem+json
- Adding JAX-RS ExceptionMapper implementations for SOFA RPC REST scenarios, reusing the same problem detail mapping logic
- Supporting extension fields such as errorCode, errorType, and service, with optional stackTrace exposure
Integrating with MessageSource so title and detail can be localized
- Adding tests for auto-configuration, MVC responses, JAX-RS mapping, compatibility behavior, and i18n