### PR TITLE
[AI-8th] Refine structured logging behavior for SOFABoot and SOFATracer

### DIFF
--- a/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/tracer/SofaTracerConfigurationListener.java
+++ b/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/tracer/SofaTracerConfigurationListener.java
@@ -32,8 +32,6 @@ import org.springframework.util.StringUtils;
 /**
  * Parse SOFATracer Configuration in early stage.
  *
- * @author qilong.zql
- * @author huzijie
  * @since 2.2.2
  */
 public class SofaTracerConfigurationListener
@@ -98,7 +96,23 @@ public class SofaTracerConfigurationListener
             String.valueOf(sofaTracerProperties.getSamplerPercentage()));
 
         SofaTracerConfiguration.setProperty(SofaTracerConfiguration.JSON_FORMAT_OUTPUT,
-            String.valueOf(sofaTracerProperties.isJsonOutput()));
+            String.valueOf(resolveJsonOutput(environment, sofaTracerProperties)));
+    }
+
+    private boolean resolveJsonOutput(ConfigurableEnvironment environment,
+                                      SofaTracerProperties sofaTracerProperties) {
+        if (Binder.get(environment).bind("sofa.boot.tracer.json-output", Boolean.class).isBound()) {
+            return sofaTracerProperties.isJsonOutput();
+        }
+        if (sofaTracerProperties.isOutputStructured()) {
+            return isStructuredLoggingEnabled(environment);
+        }
+        return sofaTracerProperties.isJsonOutput();
+    }
+
+    private boolean isStructuredLoggingEnabled(ConfigurableEnvironment environment) {
+        return StringUtils.hasText(environment.getProperty("logging.structured.format.console"))
+               || StringUtils.hasText(environment.getProperty("logging.structured.format.file"));
     }
 
     @Override

--- a/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/tracer/SofaTracerProperties.java
+++ b/sofa-boot-project/sofa-boot-autoconfigure/src/main/java/com/alipay/sofa/boot/autoconfigure/tracer/SofaTracerProperties.java
@@ -29,8 +29,6 @@ import static com.alipay.common.tracer.core.configuration.SofaTracerConfiguratio
 /**
  * Configuration properties to configure tracer.
  *
- * @author yangguanchao
- * @author huzijie
  * @since 2018/04/30
  */
 @ConfigurationProperties("sofa.boot.tracer")
@@ -92,6 +90,11 @@ public class SofaTracerProperties {
      * Use json to print log.
      */
     private boolean             jsonOutput                = true;
+
+    /**
+     * Follow SOFABoot structured logging when jsonOutput is not explicitly configured.
+     */
+    private boolean             outputStructured;
 
     public String getDisableDigestLog() {
         return disableDigestLog;
@@ -179,5 +182,13 @@ public class SofaTracerProperties {
 
     public void setJsonOutput(boolean jsonOutput) {
         this.jsonOutput = jsonOutput;
+    }
+
+    public boolean isOutputStructured() {
+        return outputStructured;
+    }
+
+    public void setOutputStructured(boolean outputStructured) {
+        this.outputStructured = outputStructured;
     }
 }

--- a/sofa-boot-project/sofa-boot-autoconfigure/src/test/java/com/alipay/sofa/boot/autoconfigure/tracer/SofaTracerConfigurationListenerTests.java
+++ b/sofa-boot-project/sofa-boot-autoconfigure/src/test/java/com/alipay/sofa/boot/autoconfigure/tracer/SofaTracerConfigurationListenerTests.java
@@ -37,9 +37,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Tests for {@link SofaTracerConfigurationListener}.
- *
- * @author huzijie
- * @version SofaTracerConfigurationListenerTests.java, v 0.1 2023年01月11日 3:28 PM huzijie Exp $
  */
 public class SofaTracerConfigurationListenerTests {
 
@@ -86,6 +83,8 @@ public class SofaTracerConfigurationListenerTests {
         props.put("sofa.boot.tracer.samplerName", "test");
         props.put("sofa.boot.tracer.samplerPercentage", "200.0");
         props.put("sofa.boot.tracer.samplerCustomRuleClassName", "TestRuleClass");
+        props.put("sofa.boot.tracer.output-structured", "true");
+        props.put("logging.structured.format.file", "ecs");
         props.put("sofa.boot.tracer.jsonOutput", "false");
         application.setDefaultProperties(props);
         application.addListeners(new SpringCloudConfigListener());
@@ -125,6 +124,39 @@ public class SofaTracerConfigurationListenerTests {
             SofaTracerConfiguration
                 .getProperty(SofaTracerConfiguration.SAMPLER_STRATEGY_CUSTOM_RULE_CLASS_NAME))
             .isEqualTo("TestRuleClass");
+        assertThat(SofaTracerConfiguration.getProperty(SofaTracerConfiguration.JSON_FORMAT_OUTPUT))
+            .isEqualTo("false");
+    }
+
+    @Test
+    public void tracerJsonOutputFollowsStructuredLogging() {
+        SpringApplication application = new SpringApplication(Config.class);
+        application.setWebApplicationType(WebApplicationType.NONE);
+        Map<String, Object> props = new HashMap<>();
+        props.put("spring.application.name", "tracer-structured");
+        props.put("sofa.boot.tracer.output-structured", "true");
+        props.put("logging.structured.format.console", "logstash");
+        application.setDefaultProperties(props);
+        application.addListeners(new SpringCloudConfigListener());
+        application.addListeners(new SofaTracerConfigurationListener());
+        this.context = application.run();
+
+        assertThat(SofaTracerConfiguration.getProperty(SofaTracerConfiguration.JSON_FORMAT_OUTPUT))
+            .isEqualTo("true");
+    }
+
+    @Test
+    public void tracerJsonOutputCanBeDisabledWhenStructuredLoggingIsDisabled() {
+        SpringApplication application = new SpringApplication(Config.class);
+        application.setWebApplicationType(WebApplicationType.NONE);
+        Map<String, Object> props = new HashMap<>();
+        props.put("spring.application.name", "tracer-pattern");
+        props.put("sofa.boot.tracer.output-structured", "true");
+        application.setDefaultProperties(props);
+        application.addListeners(new SpringCloudConfigListener());
+        application.addListeners(new SofaTracerConfigurationListener());
+        this.context = application.run();
+
         assertThat(SofaTracerConfiguration.getProperty(SofaTracerConfiguration.JSON_FORMAT_OUTPUT))
             .isEqualTo("false");
     }

--- a/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/main/resources/com/alipay/sofa/rpc/boot/log/logback/log-conf.xml
+++ b/sofa-boot-project/sofa-boot-core/rpc-sofa-boot/src/main/resources/com/alipay/sofa/rpc/boot/log/logback/log-conf.xml
@@ -20,8 +20,9 @@
             <!--日志文件保留天数-->
             <MaxHistory>30</MaxHistory>
         </rollingPolicy>
-        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+        <encoder class="com.alipay.sofa.boot.logging.logback.SofaBootStructuredLogEncoder">
             <pattern>%d %-5p %-32t - %m%n</pattern>
+            <formatProperty>FILE_LOG_STRUCTURED_FORMAT</formatProperty>
             <!-- 编码 -->
             <charset>${file.encoding}</charset>
         </encoder>
@@ -42,8 +43,9 @@
             <!--日志文件保留天数-->
             <MaxHistory>30</MaxHistory>
         </rollingPolicy>
-        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+        <encoder class="com.alipay.sofa.boot.logging.logback.SofaBootStructuredLogEncoder">
             <pattern>%d %-5p %-32t - %m%n</pattern>
+            <formatProperty>FILE_LOG_STRUCTURED_FORMAT</formatProperty>
             <!-- 编码 -->
             <charset>${file.encoding}</charset>
         </encoder>
@@ -65,8 +67,9 @@
             <!--日志文件保留天数-->
             <MaxHistory>30</MaxHistory>
         </rollingPolicy>
-        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+        <encoder class="com.alipay.sofa.boot.logging.logback.SofaBootStructuredLogEncoder">
             <pattern>%d %-5p %-32t %c{2} - %m%n</pattern>
+            <formatProperty>FILE_LOG_STRUCTURED_FORMAT</formatProperty>
             <!-- 编码 -->
             <charset>${file.encoding}</charset>
         </encoder>
@@ -87,8 +90,9 @@
             <!--日志文件保留天数-->
             <MaxHistory>30</MaxHistory>
         </rollingPolicy>
-        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+        <encoder class="com.alipay.sofa.boot.logging.logback.SofaBootStructuredLogEncoder">
             <pattern>%d %-5p %-32t %c{2} - %m%n</pattern>
+            <formatProperty>FILE_LOG_STRUCTURED_FORMAT</formatProperty>
             <!-- 编码 -->
             <charset>${file.encoding}</charset>
         </encoder>
@@ -109,8 +113,9 @@
             <!--日志文件保留天数-->
             <MaxHistory>30</MaxHistory>
         </rollingPolicy>
-        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+        <encoder class="com.alipay.sofa.boot.logging.logback.SofaBootStructuredLogEncoder">
             <pattern>%d %-5p %-32t %c{2} - %m%n</pattern>
+            <formatProperty>FILE_LOG_STRUCTURED_FORMAT</formatProperty>
             <!-- 编码 -->
             <charset>${file.encoding}</charset>
         </encoder>

--- a/sofa-boot-project/sofa-boot/pom.xml
+++ b/sofa-boot-project/sofa-boot/pom.xml
@@ -36,14 +36,14 @@
         </dependency>
 
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-            <scope>test</scope>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <optional>true</optional>
         </dependency>
 
         <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/sofa-boot-project/sofa-boot/src/main/java/com/alipay/sofa/boot/logging/logback/SofaBootStructuredLogEncoder.java
+++ b/sofa-boot-project/sofa-boot/src/main/java/com/alipay/sofa/boot/logging/logback/SofaBootStructuredLogEncoder.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.boot.logging.logback;
+
+import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.encoder.Encoder;
+import ch.qos.logback.core.encoder.EncoderBase;
+import org.springframework.boot.logging.logback.StructuredLogEncoder;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Logback encoder that keeps SOFABoot's pattern output by default and switches to
+ * Spring Boot's structured logging encoder when a structured format system property is set.
+ */
+public class SofaBootStructuredLogEncoder extends EncoderBase<ILoggingEvent> {
+
+    private String                 pattern;
+
+    private Charset                charset = StandardCharsets.UTF_8;
+
+    private String                 formatProperty;
+
+    private Encoder<ILoggingEvent> delegate;
+
+    public void setPattern(String pattern) {
+        this.pattern = pattern;
+    }
+
+    public void setCharset(Charset charset) {
+        this.charset = charset;
+    }
+
+    public void setFormatProperty(String formatProperty) {
+        this.formatProperty = formatProperty;
+    }
+
+    @Override
+    public void start() {
+        Assert.state(StringUtils.hasText(this.pattern), "Pattern has not been set");
+        Assert.state(StringUtils.hasText(this.formatProperty), "Format property has not been set");
+        this.delegate = createDelegate();
+        super.start();
+    }
+
+    private Encoder<ILoggingEvent> createDelegate() {
+        String format = System.getProperty(this.formatProperty);
+        if (StringUtils.hasText(format)) {
+            return createStructuredDelegate(format);
+        }
+        return createPatternDelegate();
+    }
+
+    private Encoder<ILoggingEvent> createStructuredDelegate(String format) {
+        StructuredLogEncoder encoder = new StructuredLogEncoder();
+        encoder.setContext(getContext());
+        encoder.setCharset((this.charset != null) ? this.charset : StandardCharsets.UTF_8);
+        encoder.setFormat(format);
+        try {
+            encoder.start();
+            return encoder;
+        } catch (RuntimeException exception) {
+            addWarn(
+                "Falling back to pattern logging because structured logging could not be initialized for "
+                        + this.formatProperty, exception);
+            encoder.stop();
+            return createPatternDelegate();
+        }
+    }
+
+    private Encoder<ILoggingEvent> createPatternDelegate() {
+        PatternLayoutEncoder encoder = new PatternLayoutEncoder();
+        encoder.setContext(getContext());
+        encoder.setPattern(this.pattern);
+        encoder.setCharset((this.charset != null) ? this.charset : StandardCharsets.UTF_8);
+        encoder.start();
+        return encoder;
+    }
+
+    @Override
+    public void stop() {
+        if (this.delegate != null) {
+            this.delegate.stop();
+        }
+        super.stop();
+    }
+
+    @Override
+    public byte[] headerBytes() {
+        return (this.delegate != null) ? this.delegate.headerBytes() : null;
+    }
+
+    @Override
+    public byte[] encode(ILoggingEvent event) {
+        Assert.state(this.delegate != null, "Encoder has not been started");
+        return this.delegate.encode(event);
+    }
+
+    @Override
+    public byte[] footerBytes() {
+        return (this.delegate != null) ? this.delegate.footerBytes() : null;
+    }
+}

--- a/sofa-boot-project/sofa-boot/src/main/resources/sofa-boot/log/logback/log-conf.xml
+++ b/sofa-boot-project/sofa-boot/src/main/resources/sofa-boot/log/logback/log-conf.xml
@@ -27,8 +27,9 @@
             <FileNamePattern>${logging.path}/sofa-runtime/common-error.log.%d{yyyy-MM-dd}</FileNamePattern>
             <MaxHistory>30</MaxHistory>
         </rollingPolicy>
-        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+        <encoder class="com.alipay.sofa.boot.logging.logback.SofaBootStructuredLogEncoder">
             <pattern>%d %-5p %-32t - %m%n</pattern>
+            <formatProperty>FILE_LOG_STRUCTURED_FORMAT</formatProperty>
             <charset>${file.encoding}</charset>
         </encoder>
     </appender>
@@ -43,8 +44,9 @@
             <FileNamePattern>${logging.path}/sofa-runtime/sofa-default.log.%d{yyyy-MM-dd}</FileNamePattern>
             <MaxHistory>30</MaxHistory>
         </rollingPolicy>
-        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+        <encoder class="com.alipay.sofa.boot.logging.logback.SofaBootStructuredLogEncoder">
             <pattern>%d %-5p %-32t - %m%n</pattern>
+            <formatProperty>FILE_LOG_STRUCTURED_FORMAT</formatProperty>
             <charset>${file.encoding}</charset>
         </encoder>
     </appender>
@@ -66,8 +68,9 @@
             <!--日志文件保留天数-->
             <MaxHistory>30</MaxHistory>
         </rollingPolicy>
-        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+        <encoder class="com.alipay.sofa.boot.logging.logback.SofaBootStructuredLogEncoder">
             <pattern>%d %-5p %-32t - %m%n</pattern>
+            <formatProperty>FILE_LOG_STRUCTURED_FORMAT</formatProperty>
             <!-- 编码 -->
             <charset>${file.encoding}</charset>
         </encoder>
@@ -88,8 +91,9 @@
             <!--日志文件保留天数-->
             <MaxHistory>30</MaxHistory>
         </rollingPolicy>
-        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+        <encoder class="com.alipay.sofa.boot.logging.logback.SofaBootStructuredLogEncoder">
             <pattern>%d %-5p %-32t - %m%n</pattern>
+            <formatProperty>FILE_LOG_STRUCTURED_FORMAT</formatProperty>
             <!-- 编码 -->
             <charset>${file.encoding}</charset>
         </encoder>

--- a/sofa-boot-project/sofa-boot/src/test/java/com/alipay/sofa/boot/logging/LogEnvironmentPreparingListenerTests.java
+++ b/sofa-boot-project/sofa-boot/src/test/java/com/alipay/sofa/boot/logging/LogEnvironmentPreparingListenerTests.java
@@ -26,9 +26,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests for {@link LogEnvironmentPostProcessor}.
- *
- * @author huzijie
- * @version LogEnvironmentPreparingListenerTests.java, v 0.1 2023年02月01日 3:35 PM huzijie Exp $
  */
 public class LogEnvironmentPreparingListenerTests {
 

--- a/sofa-boot-project/sofa-boot/src/test/java/com/alipay/sofa/boot/logging/logback/SofaBootStructuredLogEncoderTests.java
+++ b/sofa-boot-project/sofa-boot/src/test/java/com/alipay/sofa/boot/logging/logback/SofaBootStructuredLogEncoderTests.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.boot.logging.logback;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.LoggingEvent;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.env.Environment;
+import org.springframework.mock.env.MockEnvironment;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+
+public class SofaBootStructuredLogEncoderTests {
+
+    private static final String FORMAT_PROPERTY = "FILE_LOG_STRUCTURED_FORMAT";
+
+    @AfterEach
+    void clearStructuredFormatProperty() {
+        System.clearProperty(FORMAT_PROPERTY);
+    }
+
+    @Test
+    void usesPatternOutputWhenStructuredLoggingIsDisabled() {
+        LoggerContext context = new LoggerContext();
+        SofaBootStructuredLogEncoder encoder = createEncoder(context);
+
+        encoder.start();
+
+        assertThat(encoder.headerBytes()).isEmpty();
+        assertThat(encoder.footerBytes()).isEmpty();
+        assertThat(new String(encoder.encode(createEvent(context)), StandardCharsets.UTF_8))
+            .isEqualTo("hello structured logging\n");
+
+        encoder.stop();
+        context.stop();
+    }
+
+    @Test
+    void usesSpringBootStructuredEncoderWhenFormatPropertyIsSet() {
+        System.setProperty(FORMAT_PROPERTY, "logstash");
+        LoggerContext context = new LoggerContext();
+        context.putObject(Environment.class.getName(),
+            new MockEnvironment().withProperty("spring.application.name", "test-app"));
+        SofaBootStructuredLogEncoder encoder = createEncoder(context);
+
+        encoder.start();
+
+        String output = new String(encoder.encode(createEvent(context)), StandardCharsets.UTF_8);
+        assertThat(output).startsWith("{").contains("\"message\":\"hello structured logging\"")
+            .contains("\"logger_name\":\"test.logger\"").contains("\"level\":\"INFO\"");
+
+        encoder.stop();
+        context.stop();
+    }
+
+    @Test
+    void fallsBackToPatternOutputWhenStructuredEncoderCannotBeInitialized() {
+        System.setProperty(FORMAT_PROPERTY, "logstash");
+        LoggerContext context = new LoggerContext();
+        SofaBootStructuredLogEncoder encoder = createEncoder(context);
+
+        encoder.start();
+
+        assertThat(new String(encoder.encode(createEvent(context)), StandardCharsets.UTF_8))
+            .isEqualTo("hello structured logging\n");
+
+        encoder.stop();
+        context.stop();
+    }
+
+    @Test
+    void requiresPatternBeforeStart() {
+        SofaBootStructuredLogEncoder encoder = new SofaBootStructuredLogEncoder();
+        encoder.setContext(new LoggerContext());
+        encoder.setFormatProperty(FORMAT_PROPERTY);
+
+        assertThatIllegalStateException().isThrownBy(encoder::start)
+            .withMessage("Pattern has not been set");
+    }
+
+    private SofaBootStructuredLogEncoder createEncoder(LoggerContext context) {
+        SofaBootStructuredLogEncoder encoder = new SofaBootStructuredLogEncoder();
+        encoder.setContext(context);
+        encoder.setPattern("%msg%n");
+        encoder.setFormatProperty(FORMAT_PROPERTY);
+        encoder.setCharset(StandardCharsets.UTF_8);
+        return encoder;
+    }
+
+    private LoggingEvent createEvent() {
+        return createEvent(new LoggerContext());
+    }
+
+    private LoggingEvent createEvent(LoggerContext context) {
+        LoggingEvent event = new LoggingEvent();
+        event.setLoggerContext(context);
+        event.setLoggerName("test.logger");
+        event.setLevel(Level.INFO);
+        event.setMessage("hello structured logging");
+        event.setThreadName("main");
+        event.setTimeStamp(Instant.parse("2024-08-23T10:15:30Z").toEpochMilli());
+        event.setMDCPropertyMap(Collections.emptyMap());
+        return event;
+    }
+}


### PR DESCRIPTION
This PR(Related issue #1402) improves the initial structured logging support introduced for SOFABoot.

It tightens the behavior of the custom Logback structured encoder so that invalid structured logging configuration is no longer silently downgraded to pattern logging. It also adjusts the SOFATracer integration logic to avoid enabling tracer structured output based on console-only structured logging settings, which could otherwise lead to mixed log formats between SOFABoot file logs and tracer logs.

Overall, the changes make structured logging behavior more predictable, safer, and more consistent with user configuration.