### PR TITLE
Update fastjson v1 1.2.83 to fastjson v2 2.0.61 (latest)

### DIFF
--- a/sofa-boot-project/sofaboot-dependencies/pom.xml
+++ b/sofa-boot-project/sofaboot-dependencies/pom.xml
@@ -34,7 +34,7 @@
         <!--3rd lib dependency-->
         <spring.cloud.version>2025.0.0</spring.cloud.version>
         <asm.version>9.8</asm.version>
-        <fastjson.version>1.2.83</fastjson.version>
+        <fastjson.version>2.0.61</fastjson.version>
         <javassist.version>3.29.2-GA</javassist.version>
         <protobuf.version>3.22.2</protobuf.version>
         <xerces.version>2.12.2</xerces.version>
@@ -530,6 +530,12 @@
                 <groupId>org.apache.rocketmq</groupId>
                 <artifactId>rocketmq-spring-boot-starter</artifactId>
                 <version>${rocketmq.spring.boot.starter.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.alibaba</groupId>
+                        <artifactId>fastjson</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>
@@ -557,8 +563,8 @@
             </dependency>
 
             <dependency>
-                <groupId>com.alibaba</groupId>
-                <artifactId>fastjson</artifactId>
+                <groupId>com.alibaba.fastjson2</groupId>
+                <artifactId>fastjson2</artifactId>
                 <version>${fastjson.version}</version>
             </dependency>
 
@@ -690,6 +696,10 @@
                     <exclusion>
                         <artifactId>spring</artifactId>
                         <groupId>org.springframework</groupId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.alibaba</groupId>
+                        <artifactId>fastjson</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>


### PR DESCRIPTION
## Problem
`mvn dependency:tree` revealed the following issues with fastjson dependencies:
- `fastjson` v1 (`com.alibaba:fastjson:1.2.83`) was explicitly declared 
  as a direct dependency in `pom.xml` — fastjson v1 has known critical 
  CVEs (RCE, deserialization vulnerabilities) and has been superseded by 
  `fastjson2`
- Version conflict between `fastjson2:2.0.23` and `fastjson2:2.0.61` 
  being pulled transitively
- Legacy `fastjson` v1 (`com.alibaba:fastjson`) being pulled as a 
  transitive dependency unnecessarily

## Changes
- Pinned `fastjson2` to `2.0.61` in `dependencyManagement` to enforce 
  consistent version across all transitive dependencies
- Excluded legacy `fastjson` v1 transitive dependency from `rocketmq-spring-boot-starter` & `dubbo`

## Verification
```bash
mvn dependency:tree | grep fastjson
```
All references now consistently resolve to `2.0.61` with no legacy 
`fastjson` v1 present.


#### Before
<img width="1208" height="380" alt="image" src="https://github.com/user-attachments/assets/c3895f17-efe3-4d42-9ef3-3fa14db70823" />


#### After
<img width="1186" height="172" alt="image" src="https://github.com/user-attachments/assets/9a7b53c7-5663-471c-9128-ba384027115d" />
<br>
<br>

- Fixes  #1399